### PR TITLE
feat: MVPリポジトリ名生成を堅牢化し state に永続化

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -84,13 +84,50 @@ jobs:
           echo "spec_file=$SPEC_FILE" >> "$GITHUB_OUTPUT"
           echo "✅ Spec found: $SPEC_FILE"
 
-      - name: Update status to building
+      - name: Resolve product name
+        id: product-name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # 既存 state に product_name が保存されていれば再利用（冪等化）
+          EXISTING=$(python3 -c "
+          import json, os
+          state_path = 'data/pipeline_state.json'
+          if not os.path.exists(state_path):
+              print('')
+              raise SystemExit
+          state = json.load(open(state_path))
+          for item in state.get('picked', []):
+              if item['issue_number'] == int(os.environ['ISSUE_NUMBER']):
+                  print(item.get('product_name') or '')
+                  raise SystemExit
+          print('')
+          ")
+
+          if [ -n "$EXISTING" ]; then
+            echo "既存の product_name を再利用: $EXISTING"
+            PRODUCT_NAME="$EXISTING"
+          else
+            TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')
+            PRODUCT_NAME=$(python3 -m src.generate_product_name \
+              --title "$TITLE" \
+              --issue-number "$ISSUE_NUMBER")
+            echo "新規生成した product_name: $PRODUCT_NAME"
+          fi
+
+          echo "product_name=$PRODUCT_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Update state (status=building, product_name)
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PRODUCT_NAME: ${{ steps.product-name.outputs.product_name }}
         run: |
           gh issue edit "$ISSUE_NUMBER" --add-label "building"
-          gh issue comment "$ISSUE_NUMBER" --body "🚀 承認されました。自動実装を開始します..."
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "🚀 承認されました。自動実装を開始します...
+          プロダクト名: \`$PRODUCT_NAME\`（リポジトリ: kaionn/$PRODUCT_NAME）"
 
           python3 -c "
           import json, os
@@ -101,6 +138,7 @@ jobs:
           for item in state.get('picked', []):
               if item['issue_number'] == int(os.environ['ISSUE_NUMBER']):
                   item['status'] = 'building'
+                  item['product_name'] = os.environ['PRODUCT_NAME']
                   break
           json.dump(state, open(state_path, 'w'), indent=2, ensure_ascii=False)
           "
@@ -112,7 +150,7 @@ jobs:
           if [ -n "$EXISTING_SHA" ]; then
             gh api "repos/${{ github.repository }}/contents/data/pipeline_state.json" \
               -X PUT \
-              -f message="pipeline: #$ISSUE_NUMBER のステータスを building に更新" \
+              -f message="pipeline: #$ISSUE_NUMBER を building に更新 (product=$PRODUCT_NAME)" \
               -f content="$UPDATED_CONTENT" \
               -f sha="$EXISTING_SHA" \
               > /dev/null
@@ -120,7 +158,7 @@ jobs:
           else
             gh api "repos/${{ github.repository }}/contents/data/pipeline_state.json" \
               -X PUT \
-              -f message="pipeline: #$ISSUE_NUMBER のステータスを building に更新" \
+              -f message="pipeline: #$ISSUE_NUMBER を building に更新 (product=$PRODUCT_NAME)" \
               -f content="$UPDATED_CONTENT" \
               > /dev/null
             echo "✅ pipeline_state.json を作成しました"
@@ -130,6 +168,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PRODUCT_NAME: ${{ steps.product-name.outputs.product_name }}
         run: |
           # Spec ファイルの内容を base64 エンコードして渡す
           SPEC_CONTENT=$(base64 < "${{ steps.validate-spec.outputs.spec_file }}")
@@ -149,24 +188,6 @@ jobs:
           if [ -n "$DEEP_DIVE_PATH" ] && [ -f "$DEEP_DIVE_PATH" ]; then
             DEEP_DIVE_CONTENT=$(base64 < "$DEEP_DIVE_PATH")
           fi
-
-          # Issue タイトルからプロダクト名を生成（LLM で英語ケバブケースに変換）
-          TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')
-          PRODUCT_NAME=$(python3 -c "
-          import subprocess, re
-          title = '''$TITLE'''
-          # LLM でタイトルを英語ケバブケースに変換
-          result = subprocess.run(
-              ['gh', 'models', 'run', 'openai/gpt-4o-mini', '--',
-               f'Convert this to a short English kebab-case product name (max 30 chars, only lowercase letters and hyphens, no explanation): {title}'],
-              capture_output=True, text=True, timeout=30
-          )
-          name = result.stdout.strip().lower().replace(' ', '-')
-          name = re.sub(r'[^a-z0-9-]', '', name).strip('-')[:30]
-          if not name or name == '-':
-              name = f'mvp-{$ISSUE_NUMBER}'
-          print(name)
-          ")
 
           gh workflow run build.yml \
             --repo kaionn/mvp-factory \

--- a/src/generate_product_name.py
+++ b/src/generate_product_name.py
@@ -1,0 +1,193 @@
+"""Issue タイトルから MVP リポジトリ用のプロダクト名（英語ケバブケース）を生成する.
+
+LLM（gh models run openai/gpt-4o-mini）で変換し、失敗時は mvp-{issue_number} にフォールバックする。
+CLAUDE.md のルールに従い subprocess の returncode を必ずチェックしてエラーログを出す。
+"""
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+MAX_LENGTH = 30
+MIN_LENGTH = 3
+
+# プロダクト名として意味のない単独語（フォールバック判定に使う）
+_BANNED_NAMES = frozenset({
+    "mvp",
+    "app",
+    "application",
+    "product",
+    "service",
+    "tool",
+    "test",
+    "temp",
+    "tmp",
+    "demo",
+    "example",
+    "project",
+    "name",
+    "unknown",
+})
+
+_PROMPT_TEMPLATE = (
+    "Convert the following Japanese product idea title to a concise English "
+    "kebab-case repository name.\n"
+    "Rules:\n"
+    "- Output ONLY the name. No quotes, no explanation, no code fence.\n"
+    "- Max {max_length} characters.\n"
+    "- Only lowercase letters, digits, and hyphens.\n"
+    "- 2-4 words, describing the product concretely (avoid generic words like app/mvp/tool).\n"
+    "- Prefer domain nouns over verbs.\n\n"
+    "Title: {title}"
+)
+
+
+def _extract_kebab_token(raw: str) -> str:
+    """LLM の出力から最もそれらしいケバブケース文字列を抽出する.
+
+    LLM が説明文・コードフェンス・引用符付きで返した場合でも、有効な
+    ケバブケース token を拾う。候補が複数あれば最長のものを選ぶ。
+    """
+    text = raw.strip().lower()
+    text = text.strip("`\"'")
+
+    # コードフェンスや quote を剥がした後の行単位で候補を探す
+    candidates: list[str] = []
+    for line in text.splitlines():
+        for token in re.findall(r"[a-z0-9][a-z0-9-]*[a-z0-9]", line):
+            candidates.append(token)
+
+    if not candidates:
+        return ""
+
+    # ハイフンを含む（＝複数語で構成される）候補を優先
+    hyphenated = [c for c in candidates if "-" in c]
+    pool = hyphenated or candidates
+    return max(pool, key=len)
+
+
+def _sanitize(name: str) -> str:
+    """ケバブケース token として正規化する."""
+    name = name.lower()
+    name = re.sub(r"[^a-z0-9-]", "-", name)
+    name = re.sub(r"-{2,}", "-", name)
+    name = name.strip("-")
+    return name[:MAX_LENGTH].rstrip("-")
+
+
+def _is_valid(name: str) -> bool:
+    """生成されたプロダクト名が採用可能かどうか."""
+    if len(name) < MIN_LENGTH:
+        return False
+    if name in _BANNED_NAMES:
+        return False
+    # ハイフンも数字もない単一単語で、かつ禁止語集合に近い形（app1 等）を追加検査したいが
+    # まずはハイフン有無のチェックに留める
+    if re.fullmatch(r"[0-9-]+", name):
+        return False
+    return True
+
+
+def _call_gh_models(title: str, *, timeout: int = 30) -> str | None:
+    """gh models run を呼び出して出力を返す。失敗時は None."""
+    prompt = _PROMPT_TEMPLATE.format(max_length=MAX_LENGTH, title=title)
+    try:
+        result = subprocess.run(
+            ["gh", "models", "run", "openai/gpt-4o-mini", "--", prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        logger.error("gh コマンドが見つかりません")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.error("gh models run がタイムアウトしました (title=%r)", title)
+        return None
+
+    if result.returncode != 0:
+        logger.error(
+            "gh models run 失敗 (rc=%s, stderr=%s)",
+            result.returncode,
+            (result.stderr or "").strip()[:500],
+        )
+        return None
+
+    stdout = (result.stdout or "").strip()
+    if not stdout:
+        logger.error("gh models run の stdout が空でした")
+        return None
+
+    logger.info("LLM 応答（生）: %r", stdout[:200])
+    return stdout
+
+
+def generate(title: str, issue_number: int, *, timeout: int = 30) -> str:
+    """タイトルからプロダクト名を生成する.
+
+    Args:
+        title: Issue タイトル（日本語想定）。
+        issue_number: フォールバック用の Issue 番号。
+        timeout: LLM 呼び出しのタイムアウト秒数。
+
+    Returns:
+        kebab-case のプロダクト名。LLM が失敗したら ``mvp-{issue_number}``。
+    """
+    raw = _call_gh_models(title, timeout=timeout)
+    if raw is not None:
+        token = _extract_kebab_token(raw)
+        name = _sanitize(token)
+        if _is_valid(name):
+            logger.info("プロダクト名を生成: %s", name)
+            return name
+        logger.warning(
+            "LLM 出力が無効のためフォールバック (raw=%r, sanitized=%r)",
+            raw[:200],
+            name,
+        )
+
+    fallback = f"mvp-{issue_number}"
+    logger.warning("フォールバック名を使用: %s", fallback)
+    return fallback
+
+
+def _build_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--title", required=True, help="Issue タイトル")
+    parser.add_argument(
+        "--issue-number",
+        required=True,
+        type=int,
+        help="フォールバック用の Issue 番号",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="LLM 呼び出しのタイムアウト秒数（デフォルト 30）",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI エントリポイント。stdout に生成されたプロダクト名を出力する."""
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+    parser = _build_cli_parser()
+    args = parser.parse_args(argv)
+
+    name = generate(args.title, args.issue_number, timeout=args.timeout)
+    print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/issue_commands.py
+++ b/src/issue_commands.py
@@ -140,6 +140,7 @@ def cmd_pick(issue_number: int, args: list[str] | None = None) -> int:
         "picked_at": _now(),
         "spec": None,
         "deep_dive": None,
+        "product_name": None,
         "status": "picked",
         "source": "issue-command",
         "events": [],

--- a/src/pick_idea.py
+++ b/src/pick_idea.py
@@ -366,6 +366,7 @@ def _update_pipeline_state(picked: list[dict], today: str) -> None:
             "picked_at": datetime.now(JST).isoformat(),
             "spec": item.get("spec"),
             "deep_dive": item.get("deep_dive"),
+            "product_name": None,
             "status": "awaiting_approval",
         })
 

--- a/tests/test_generate_product_name.py
+++ b/tests/test_generate_product_name.py
@@ -1,0 +1,166 @@
+"""generate_product_name.py の純粋ロジックのユニットテスト.
+
+gh models run 呼び出し（subprocess）はモックせず、抽出・サニタイズ・
+妥当性検査の純粋関数のみ検証する。generate() 自体は _call_gh_models を
+monkeypatch して振る舞いを確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src import generate_product_name as gpn
+
+
+class TestExtractKebabToken:
+    def test_returns_hyphenated_token_when_mixed_with_explanation(self):
+        raw = "Here's the name:\nsubscription-cancel-tracker\nHope it helps!"
+        assert gpn._extract_kebab_token(raw) == "subscription-cancel-tracker"
+
+    def test_strips_code_fence(self):
+        raw = "```\nfood-delivery-refund\n```"
+        assert gpn._extract_kebab_token(raw) == "food-delivery-refund"
+
+    def test_picks_longest_hyphenated_when_multiple_candidates(self):
+        raw = "app or subscription-cancel-tracker"
+        assert gpn._extract_kebab_token(raw) == "subscription-cancel-tracker"
+
+    def test_falls_back_to_single_word_when_no_hyphenated(self):
+        raw = "tracker"
+        assert gpn._extract_kebab_token(raw) == "tracker"
+
+    def test_empty_input_returns_empty_string(self):
+        assert gpn._extract_kebab_token("") == ""
+
+    def test_japanese_only_returns_empty_string(self):
+        assert gpn._extract_kebab_token("お金の管理アプリ") == ""
+
+
+class TestSanitize:
+    def test_lowercases_and_trims(self):
+        assert gpn._sanitize("Subscription-Cancel-Tracker") == "subscription-cancel-tracker"
+
+    def test_replaces_invalid_chars_with_hyphen(self):
+        assert gpn._sanitize("foo_bar baz") == "foo-bar-baz"
+
+    def test_collapses_consecutive_hyphens(self):
+        assert gpn._sanitize("foo--bar---baz") == "foo-bar-baz"
+
+    def test_strips_leading_trailing_hyphens(self):
+        assert gpn._sanitize("---foo-bar---") == "foo-bar"
+
+    def test_truncates_to_max_length(self):
+        long = "a" * 50
+        assert len(gpn._sanitize(long)) == gpn.MAX_LENGTH
+
+    def test_trailing_hyphen_after_truncation_is_stripped(self):
+        # 29 文字 + "-x" だと 30 文字目がハイフンになるケースの保険
+        name = "abcdefghijklmnopqrstuvwxyz12-xyz"
+        result = gpn._sanitize(name)
+        assert not result.endswith("-")
+        assert len(result) <= gpn.MAX_LENGTH
+
+
+class TestIsValid:
+    def test_valid_kebab_case(self):
+        assert gpn._is_valid("subscription-cancel-tracker")
+
+    def test_too_short_rejected(self):
+        assert not gpn._is_valid("ab")
+
+    def test_banned_name_rejected(self):
+        assert not gpn._is_valid("mvp")
+        assert not gpn._is_valid("app")
+        assert not gpn._is_valid("test")
+
+    def test_numeric_only_rejected(self):
+        assert not gpn._is_valid("104")
+        assert not gpn._is_valid("12-34")
+
+
+class TestGenerate:
+    def test_uses_llm_output_when_valid(self, monkeypatch):
+        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "subscription-cancel-tracker")
+        assert gpn.generate("解約管理", issue_number=42) == "subscription-cancel-tracker"
+
+    def test_fallback_when_llm_returns_none(self, monkeypatch):
+        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: None)
+        assert gpn.generate("anything", issue_number=104) == "mvp-104"
+
+    def test_fallback_when_llm_returns_banned_word(self, monkeypatch):
+        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "app")
+        assert gpn.generate("anything", issue_number=97) == "mvp-97"
+
+    def test_fallback_when_llm_returns_only_japanese(self, monkeypatch):
+        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "アプリ")
+        assert gpn.generate("anything", issue_number=50) == "mvp-50"
+
+    def test_extracts_from_llm_explanation(self, monkeypatch):
+        monkeypatch.setattr(
+            gpn,
+            "_call_gh_models",
+            lambda title, timeout=30: "Sure, here's a good name:\nfood-delivery-refund",
+        )
+        assert gpn.generate("Uber Eats 返金", issue_number=104) == "food-delivery-refund"
+
+
+class TestCallGhModels:
+    def test_returncode_non_zero_returns_none(self, monkeypatch):
+        class FakeResult:
+            returncode = 1
+            stdout = ""
+            stderr = "auth error"
+
+        def fake_run(*args, **kwargs):
+            return FakeResult()
+
+        monkeypatch.setattr(gpn.subprocess, "run", fake_run)
+        assert gpn._call_gh_models("title") is None
+
+    def test_empty_stdout_returns_none(self, monkeypatch):
+        class FakeResult:
+            returncode = 0
+            stdout = "   \n"
+            stderr = ""
+
+        monkeypatch.setattr(gpn.subprocess, "run", lambda *a, **kw: FakeResult())
+        assert gpn._call_gh_models("title") is None
+
+    def test_timeout_returns_none(self, monkeypatch):
+        def raise_timeout(*args, **kwargs):
+            raise gpn.subprocess.TimeoutExpired(cmd="gh", timeout=30)
+
+        monkeypatch.setattr(gpn.subprocess, "run", raise_timeout)
+        assert gpn._call_gh_models("title") is None
+
+    def test_gh_not_found_returns_none(self, monkeypatch):
+        def raise_fnf(*args, **kwargs):
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(gpn.subprocess, "run", raise_fnf)
+        assert gpn._call_gh_models("title") is None
+
+    def test_success_returns_stdout_stripped(self, monkeypatch):
+        class FakeResult:
+            returncode = 0
+            stdout = "  food-delivery-refund  \n"
+            stderr = ""
+
+        monkeypatch.setattr(gpn.subprocess, "run", lambda *a, **kw: FakeResult())
+        assert gpn._call_gh_models("title") == "food-delivery-refund"
+
+
+class TestCli:
+    def test_main_prints_generated_name(self, monkeypatch, capsys):
+        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "subscription-cancel-tracker")
+        rc = gpn.main(["--title", "Uber Eats 解約", "--issue-number", "104"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "subscription-cancel-tracker"
+
+    def test_main_prints_fallback_on_failure(self, monkeypatch, capsys):
+        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: None)
+        rc = gpn.main(["--title", "something", "--issue-number", "104"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "mvp-104"


### PR DESCRIPTION
## 背景

`/approve` で作られる MVP リポジトリ名が `kaionn/mvp-104` のような Issue 番号のフォールバックになっていた。原因は `.github/workflows/approve.yml` 内のインライン Python で以下の問題があったため:

- `subprocess.run` の returncode を検査していない（CLAUDE.md のルール違反）
- f-string `f'mvp-{\$ISSUE_NUMBER}'` 内の `\$ISSUE_NUMBER` が bash で先に展開されて fallback が容易に発火
- LLM 出力のサニタイズが粗く、説明文混じりで空文字になるケースを検知不能
- LLM 応答が一切ログに残らず原因追跡不能
- 生成名が `pipeline_state.json` に保存されず再実行で変わりうる

## 変更内容

- `src/generate_product_name.py` を新規追加: LLM 呼び出し + サニタイズ + 堅牢な fallback + CLI。`subprocess.run` の returncode / timeout / FileNotFoundError を全チェック。説明文混じりでも kebab token を抽出。`mvp` / `app` / `test` 等の禁止語や数字のみは reject して fallback へ。
- `.github/workflows/approve.yml` を簡素化: インライン Python を撤去し `python3 -m src.generate_product_name` 呼び出しに統一。state に既存 `product_name` があれば再利用（冪等化）。承認コメントに生成されたリポジトリ名を表示。
- `src/pick_idea.py` / `src/issue_commands.py`: state schema に `product_name: None` を追加。
- `tests/test_generate_product_name.py`: 28 ケース（抽出・サニタイズ・妥当性・LLM 失敗時フォールバック・CLI）。

## テスト

- 新規 28/28 パス、全体 179/179 パス
- YAML 構文チェック OK
- ローカル CLI スモーク: \`gh models\` 不在時に警告ログ付きで \`mvp-104\` に fallback 動作確認

## 関連

- mvp-factory 側の Plan B: https://github.com/kaionn/mvp-factory/pull/1