### PR TITLE
feat: pipeline_state の atomic write と broken JSON 耐性（D-1）

### DIFF
--- a/src/issue_commands.py
+++ b/src/issue_commands.py
@@ -48,16 +48,52 @@ HELP_TEXT = gh_client.HELP_BLOCK
 # ---------------------------------------------------------------------------
 
 def _load_state() -> dict:
+    """pipeline_state.json をロードする.
+
+    ファイルが存在しない、または JSON パース失敗時は空 state にフォールバックする。
+    """
     if not os.path.exists(PIPELINE_STATE_PATH):
         return {"picked": []}
-    with open(PIPELINE_STATE_PATH, encoding="utf-8") as f:
-        return json.load(f)
+    try:
+        with open(PIPELINE_STATE_PATH, encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        logger = logging.getLogger(__name__)
+        logger.error(
+            "pipeline_state.json のパースに失敗（空 state にフォールバック）: %s", exc
+        )
+        return {"picked": []}
 
 
 def _save_state(state: dict) -> None:
-    os.makedirs(os.path.dirname(PIPELINE_STATE_PATH), exist_ok=True)
-    with open(PIPELINE_STATE_PATH, "w", encoding="utf-8") as f:
-        json.dump(state, f, indent=2, ensure_ascii=False)
+    """pipeline_state.json を atomic に書き込む.
+
+    write-to-tmp + os.replace で、書き込み中のクラッシュや並行 read による
+    部分書き込みファイル参照を防ぐ。同一プロセスの並行書き込みでも tmp ファイル名が
+    衝突しないよう ``tempfile.mkstemp`` で unique 名を生成する。
+    """
+    import tempfile
+
+    state_dir = os.path.dirname(PIPELINE_STATE_PATH)
+    os.makedirs(state_dir, exist_ok=True)
+    base_name = os.path.basename(PIPELINE_STATE_PATH)
+
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=state_dir,
+        prefix=f"{base_name}.tmp.",
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, PIPELINE_STATE_PATH)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
     # ワークフローに「state を書き換えた」と通知
     with open(STATE_DIRTY_FLAG, "w") as f:
         f.write("1")

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1,0 +1,157 @@
+"""pipeline_state.json の load/save の安全性テスト.
+
+D-1 の一部: race condition 耐性、broken JSON フォールバック、atomic write を検証する。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from src import issue_commands
+
+
+@pytest.fixture
+def isolated_state(monkeypatch, tmp_path):
+    """PIPELINE_STATE_PATH を tmp_path に切り替える."""
+    state_path = tmp_path / "pipeline_state.json"
+    dirty_path = tmp_path / ".state_dirty"
+    monkeypatch.setattr(issue_commands, "PIPELINE_STATE_PATH", str(state_path))
+    monkeypatch.setattr(issue_commands, "STATE_DIRTY_FLAG", str(dirty_path))
+    return tmp_path
+
+
+class TestLoadState:
+    def test_returns_default_when_file_absent(self, isolated_state):
+        assert issue_commands._load_state() == {"picked": []}
+
+    def test_returns_parsed_state_when_file_valid(self, isolated_state):
+        state_path = isolated_state / "pipeline_state.json"
+        state_path.write_text(
+            json.dumps({"picked": [{"issue_number": 1}]}),
+            encoding="utf-8",
+        )
+        assert issue_commands._load_state() == {"picked": [{"issue_number": 1}]}
+
+    def test_falls_back_to_default_on_broken_json(self, isolated_state, caplog):
+        state_path = isolated_state / "pipeline_state.json"
+        state_path.write_text("{ broken json", encoding="utf-8")
+
+        with caplog.at_level("ERROR"):
+            result = issue_commands._load_state()
+
+        assert result == {"picked": []}
+        assert any("パースに失敗" in r.message for r in caplog.records)
+
+    def test_falls_back_to_default_on_truncated_file(self, isolated_state):
+        """書き込み途中で kill された場合のシミュレーション."""
+        state_path = isolated_state / "pipeline_state.json"
+        state_path.write_text('{"picked": [{"issu', encoding="utf-8")
+        assert issue_commands._load_state() == {"picked": []}
+
+
+class TestSaveState:
+    def test_writes_state_to_disk(self, isolated_state):
+        state = {"picked": [{"issue_number": 42}]}
+        issue_commands._save_state(state)
+
+        state_path = isolated_state / "pipeline_state.json"
+        assert json.loads(state_path.read_text(encoding="utf-8")) == state
+
+    def test_creates_dirty_flag(self, isolated_state):
+        issue_commands._save_state({"picked": []})
+        assert (isolated_state / ".state_dirty").exists()
+
+    def test_creates_directory_if_missing(self, isolated_state, monkeypatch):
+        nested = isolated_state / "deep" / "data"
+        state_path = nested / "pipeline_state.json"
+        monkeypatch.setattr(issue_commands, "PIPELINE_STATE_PATH", str(state_path))
+
+        issue_commands._save_state({"picked": []})
+        assert state_path.exists()
+
+    def test_does_not_leave_tmp_file(self, isolated_state):
+        issue_commands._save_state({"picked": []})
+
+        # tmp ファイルが残っていないこと
+        leftover = list(isolated_state.glob("*.tmp.*"))
+        assert leftover == []
+
+    def test_atomic_write_does_not_leave_tmp_on_failure(self, isolated_state, monkeypatch):
+        """書き込み失敗時に tmp ファイルが残らないこと."""
+        original_replace = os.replace
+
+        def failing_replace(*args, **kwargs):
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr("os.replace", failing_replace)
+
+        with pytest.raises(OSError):
+            issue_commands._save_state({"picked": []})
+
+        leftover = list(isolated_state.glob("*.tmp.*"))
+        assert leftover == []
+        # 元ファイルは作成されていない
+        assert not (isolated_state / "pipeline_state.json").exists()
+
+    def test_concurrent_save_no_partial_read(self, isolated_state):
+        """複数スレッドから同時 save が走っても、読み手は常に valid な JSON を見る.
+
+        atomic write (os.replace) によって、書き込み途中の partial state は外部から見えない。
+        """
+        # 初期状態を書く
+        issue_commands._save_state({"picked": [{"issue_number": 0}]})
+
+        results: list[dict | str] = []
+
+        def writer(n: int):
+            issue_commands._save_state({"picked": [{"issue_number": n}]})
+
+        def reader():
+            for _ in range(50):
+                try:
+                    state = issue_commands._load_state()
+                    # picked が必ず list で issue_number を持っていること
+                    assert isinstance(state, dict)
+                    assert "picked" in state
+                    results.append(state)
+                except (json.JSONDecodeError, ValueError) as exc:
+                    results.append(f"FAILED: {exc}")
+
+        writers = [threading.Thread(target=writer, args=(i,)) for i in range(10)]
+        readers = [threading.Thread(target=reader) for _ in range(3)]
+
+        for t in writers + readers:
+            t.start()
+        for t in writers + readers:
+            t.join()
+
+        # 1 件も partial read 起因のエラーがないこと
+        failures = [r for r in results if isinstance(r, str)]
+        assert failures == [], f"partial read detected: {failures[:3]}"
+
+
+class TestRoundtrip:
+    def test_save_then_load_returns_same_state(self, isolated_state):
+        original = {
+            "picked": [
+                {
+                    "issue_number": 1,
+                    "title": "テスト",
+                    "events": [{"action": "pick", "at": "2026-04-18T00:00:00+09:00"}],
+                }
+            ]
+        }
+        issue_commands._save_state(original)
+        assert issue_commands._load_state() == original
+
+    def test_save_overwrite_replaces_old_content(self, isolated_state):
+        issue_commands._save_state({"picked": [{"issue_number": 1}]})
+        issue_commands._save_state({"picked": [{"issue_number": 2}]})
+
+        loaded = issue_commands._load_state()
+        assert loaded["picked"] == [{"issue_number": 2}]


### PR DESCRIPTION
## Summary

Plan #128 の D-1 を実装。\`issue_commands.py\` の state 永続化を堅牢化し、書き込み中のクラッシュや並行読み込みによる partial read を防ぐ。

## 変更内容

### \`src/issue_commands.py\`

- \`_load_state\`: \`JSONDecodeError\` を catch して空 state にフォールバック (warning ログあり)
- \`_save_state\`: \`tempfile.mkstemp\` で unique な tmp ファイル名を生成し \`os.replace\` で atomic に置換
  - \`os.fsync\` で kernel buffer を disk にフラッシュ
  - 失敗時は tmp ファイルを必ずクリーンアップ
  - 同一プロセス並行書き込みでも tmp ファイル名衝突しない

### \`tests/test_pipeline_state.py\` (12 ケース)

- load/save の基本動作
- broken JSON / truncated file のフォールバック
- 失敗時 (os.replace が OSError) の tmp ファイル残留防止
- **10 writer + 3 reader 並行下で partial read が起きないこと**
- save → load の roundtrip 一致

## 関連

Closes #128 (の D-1 部分)

## Test plan

- [x] 233 / 233 tests pass (新規 12 + 既存 221)
- [x] 並行アクセス下でも JSON パースエラーが起きないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)