### PR TITLE
fix: approve.yml の product_name 生成を GitHub Models API に統一

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
+  models: read
 
 jobs:
   check-approve:

--- a/data/pipeline_state.json
+++ b/data/pipeline_state.json
@@ -83,9 +83,18 @@
             "path": "specs/issue-117-spec.md",
             "force": true
           }
+        },
+        {
+          "action": "rename",
+          "at": "2026-04-18T13:34:42.148125+09:00",
+          "payload": {
+            "from": "mvp-117",
+            "to": "subscription-guard",
+            "reason": "LLM による命名失敗（gh models 拡張未インストール）のフォールバックを手動リネームで修正"
+          }
         }
       ],
-      "product_name": "mvp-117"
+      "product_name": "subscription-guard"
     }
   ]
 }

--- a/src/generate_product_name.py
+++ b/src/generate_product_name.py
@@ -1,7 +1,8 @@
 """Issue タイトルから MVP リポジトリ用のプロダクト名（英語ケバブケース）を生成する.
 
-LLM（gh models run openai/gpt-4o-mini）で変換し、失敗時は mvp-{issue_number} にフォールバックする。
-CLAUDE.md のルールに従い subprocess の returncode を必ずチェックしてエラーログを出す。
+GitHub Models Inference API（OpenAI SDK 経由）で変換し、失敗時は
+``mvp-{issue_number}`` にフォールバックする。``GITHUB_TOKEN`` が無い環境では
+ローカル claude CLI にフォールバックする（``generate_spec.py`` と同じ方針）。
 """
 
 import argparse
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 MAX_LENGTH = 30
 MIN_LENGTH = 3
+LLM_TIMEOUT_SEC = 30
 
 # プロダクト名として意味のない単独語（フォールバック判定に使う）
 _BANNED_NAMES = frozenset({
@@ -34,29 +36,20 @@ _BANNED_NAMES = frozenset({
     "unknown",
 })
 
-_PROMPT_TEMPLATE = (
-    "Convert the following Japanese product idea title to a concise English "
-    "kebab-case repository name.\n"
-    "Rules:\n"
-    "- Output ONLY the name. No quotes, no explanation, no code fence.\n"
-    "- Max {max_length} characters.\n"
-    "- Only lowercase letters, digits, and hyphens.\n"
-    "- 2-4 words, describing the product concretely (avoid generic words like app/mvp/tool).\n"
-    "- Prefer domain nouns over verbs.\n\n"
-    "Title: {title}"
+_SYSTEM_PROMPT = (
+    "You convert Japanese product idea titles into concise English kebab-case "
+    "repository names. Output ONLY the name — no quotes, no explanation, no "
+    "code fence. Max 30 characters. Only lowercase letters, digits, and hyphens. "
+    "2-4 words, describing the product concretely (avoid generic words like "
+    "app/mvp/tool). Prefer domain nouns over verbs."
 )
 
 
 def _extract_kebab_token(raw: str) -> str:
-    """LLM の出力から最もそれらしいケバブケース文字列を抽出する.
-
-    LLM が説明文・コードフェンス・引用符付きで返した場合でも、有効な
-    ケバブケース token を拾う。候補が複数あれば最長のものを選ぶ。
-    """
+    """LLM の出力から最もそれらしいケバブケース文字列を抽出する."""
     text = raw.strip().lower()
     text = text.strip("`\"'")
 
-    # コードフェンスや quote を剥がした後の行単位で候補を探す
     candidates: list[str] = []
     for line in text.splitlines():
         for token in re.findall(r"[a-z0-9][a-z0-9-]*[a-z0-9]", line):
@@ -65,7 +58,6 @@ def _extract_kebab_token(raw: str) -> str:
     if not candidates:
         return ""
 
-    # ハイフンを含む（＝複数語で構成される）候補を優先
     hyphenated = [c for c in candidates if "-" in c]
     pool = hyphenated or candidates
     return max(pool, key=len)
@@ -86,33 +78,66 @@ def _is_valid(name: str) -> bool:
         return False
     if name in _BANNED_NAMES:
         return False
-    # ハイフンも数字もない単一単語で、かつ禁止語集合に近い形（app1 等）を追加検査したいが
-    # まずはハイフン有無のチェックに留める
     if re.fullmatch(r"[0-9-]+", name):
         return False
     return True
 
 
-def _call_gh_models(title: str, *, timeout: int = 30) -> str | None:
-    """gh models run を呼び出して出力を返す。失敗時は None."""
-    prompt = _PROMPT_TEMPLATE.format(max_length=MAX_LENGTH, title=title)
+def _call_llm(title: str, *, timeout: int = LLM_TIMEOUT_SEC) -> str | None:
+    """LLM を呼び出してプロダクト名候補の生文字列を返す。失敗時は None.
+
+    - GITHUB_TOKEN がある場合: GitHub Models Inference API（OpenAI SDK）
+    - 無い場合: ローカル claude CLI にフォールバック
+    """
+    token = os.environ.get("GITHUB_TOKEN", "")
+    user_prompt = f"Title: {title}"
+
+    if token:
+        try:
+            from openai import OpenAI
+
+            client = OpenAI(
+                base_url="https://models.github.ai/inference",
+                api_key=token,
+            )
+            response = client.chat.completions.create(
+                model="openai/gpt-4o-mini",
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.3,
+                timeout=timeout,
+            )
+            content = (response.choices[0].message.content or "").strip()
+            if not content:
+                logger.error("GitHub Models の応答が空でした")
+                return None
+            logger.info("LLM 応答（生）: %r", content[:200])
+            return content
+        except Exception as e:
+            logger.error("GitHub Models 呼び出し失敗: %s", str(e)[:300])
+            return None
+
+    # ローカルフォールバック: claude CLI
+    combined = f"{_SYSTEM_PROMPT}\n\n{user_prompt}"
     try:
         result = subprocess.run(
-            ["gh", "models", "run", "openai/gpt-4o-mini", "--", prompt],
+            ["claude", "-p", combined, "--output-format", "text"],
             capture_output=True,
             text=True,
             timeout=timeout,
         )
     except FileNotFoundError:
-        logger.error("gh コマンドが見つかりません")
+        logger.error("claude CLI が見つかりません")
         return None
     except subprocess.TimeoutExpired:
-        logger.error("gh models run がタイムアウトしました (title=%r)", title)
+        logger.error("claude CLI がタイムアウトしました (title=%r)", title)
         return None
 
     if result.returncode != 0:
         logger.error(
-            "gh models run 失敗 (rc=%s, stderr=%s)",
+            "claude CLI 失敗 (rc=%s, stderr=%s)",
             result.returncode,
             (result.stderr or "").strip()[:500],
         )
@@ -120,25 +145,16 @@ def _call_gh_models(title: str, *, timeout: int = 30) -> str | None:
 
     stdout = (result.stdout or "").strip()
     if not stdout:
-        logger.error("gh models run の stdout が空でした")
+        logger.error("claude CLI の stdout が空でした")
         return None
 
     logger.info("LLM 応答（生）: %r", stdout[:200])
     return stdout
 
 
-def generate(title: str, issue_number: int, *, timeout: int = 30) -> str:
-    """タイトルからプロダクト名を生成する.
-
-    Args:
-        title: Issue タイトル（日本語想定）。
-        issue_number: フォールバック用の Issue 番号。
-        timeout: LLM 呼び出しのタイムアウト秒数。
-
-    Returns:
-        kebab-case のプロダクト名。LLM が失敗したら ``mvp-{issue_number}``。
-    """
-    raw = _call_gh_models(title, timeout=timeout)
+def generate(title: str, issue_number: int, *, timeout: int = LLM_TIMEOUT_SEC) -> str:
+    """タイトルからプロダクト名を生成する。失敗時は ``mvp-{issue_number}``."""
+    raw = _call_llm(title, timeout=timeout)
     if raw is not None:
         token = _extract_kebab_token(raw)
         name = _sanitize(token)
@@ -168,8 +184,8 @@ def _build_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=30,
-        help="LLM 呼び出しのタイムアウト秒数（デフォルト 30）",
+        default=LLM_TIMEOUT_SEC,
+        help=f"LLM 呼び出しのタイムアウト秒数（デフォルト {LLM_TIMEOUT_SEC}）",
     )
     return parser
 

--- a/tests/test_generate_product_name.py
+++ b/tests/test_generate_product_name.py
@@ -1,8 +1,7 @@
 """generate_product_name.py の純粋ロジックのユニットテスト.
 
-gh models run 呼び出し（subprocess）はモックせず、抽出・サニタイズ・
-妥当性検査の純粋関数のみ検証する。generate() 自体は _call_gh_models を
-monkeypatch して振る舞いを確認する。
+LLM 呼び出し（``_call_llm``）は monkeypatch でモックし、抽出・サニタイズ・
+妥当性検査・fallback の振る舞いを検証する。
 """
 
 from __future__ import annotations
@@ -54,7 +53,6 @@ class TestSanitize:
         assert len(gpn._sanitize(long)) == gpn.MAX_LENGTH
 
     def test_trailing_hyphen_after_truncation_is_stripped(self):
-        # 29 文字 + "-x" だと 30 文字目がハイフンになるケースの保険
         name = "abcdefghijklmnopqrstuvwxyz12-xyz"
         result = gpn._sanitize(name)
         assert not result.endswith("-")
@@ -80,42 +78,45 @@ class TestIsValid:
 
 class TestGenerate:
     def test_uses_llm_output_when_valid(self, monkeypatch):
-        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "subscription-cancel-tracker")
+        monkeypatch.setattr(gpn, "_call_llm", lambda title, timeout=30: "subscription-cancel-tracker")
         assert gpn.generate("解約管理", issue_number=42) == "subscription-cancel-tracker"
 
     def test_fallback_when_llm_returns_none(self, monkeypatch):
-        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: None)
+        monkeypatch.setattr(gpn, "_call_llm", lambda title, timeout=30: None)
         assert gpn.generate("anything", issue_number=104) == "mvp-104"
 
     def test_fallback_when_llm_returns_banned_word(self, monkeypatch):
-        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "app")
+        monkeypatch.setattr(gpn, "_call_llm", lambda title, timeout=30: "app")
         assert gpn.generate("anything", issue_number=97) == "mvp-97"
 
     def test_fallback_when_llm_returns_only_japanese(self, monkeypatch):
-        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "アプリ")
+        monkeypatch.setattr(gpn, "_call_llm", lambda title, timeout=30: "アプリ")
         assert gpn.generate("anything", issue_number=50) == "mvp-50"
 
     def test_extracts_from_llm_explanation(self, monkeypatch):
         monkeypatch.setattr(
             gpn,
-            "_call_gh_models",
+            "_call_llm",
             lambda title, timeout=30: "Sure, here's a good name:\nfood-delivery-refund",
         )
         assert gpn.generate("Uber Eats 返金", issue_number=104) == "food-delivery-refund"
 
 
-class TestCallGhModels:
+class TestCallLlmFallbackCli:
+    """GITHUB_TOKEN が無い環境で claude CLI にフォールバックする経路のテスト."""
+
+    @pytest.fixture(autouse=True)
+    def clear_token(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
     def test_returncode_non_zero_returns_none(self, monkeypatch):
         class FakeResult:
             returncode = 1
             stdout = ""
             stderr = "auth error"
 
-        def fake_run(*args, **kwargs):
-            return FakeResult()
-
-        monkeypatch.setattr(gpn.subprocess, "run", fake_run)
-        assert gpn._call_gh_models("title") is None
+        monkeypatch.setattr(gpn.subprocess, "run", lambda *a, **kw: FakeResult())
+        assert gpn._call_llm("title") is None
 
     def test_empty_stdout_returns_none(self, monkeypatch):
         class FakeResult:
@@ -124,21 +125,21 @@ class TestCallGhModels:
             stderr = ""
 
         monkeypatch.setattr(gpn.subprocess, "run", lambda *a, **kw: FakeResult())
-        assert gpn._call_gh_models("title") is None
+        assert gpn._call_llm("title") is None
 
     def test_timeout_returns_none(self, monkeypatch):
         def raise_timeout(*args, **kwargs):
-            raise gpn.subprocess.TimeoutExpired(cmd="gh", timeout=30)
+            raise gpn.subprocess.TimeoutExpired(cmd="claude", timeout=30)
 
         monkeypatch.setattr(gpn.subprocess, "run", raise_timeout)
-        assert gpn._call_gh_models("title") is None
+        assert gpn._call_llm("title") is None
 
-    def test_gh_not_found_returns_none(self, monkeypatch):
+    def test_cli_not_found_returns_none(self, monkeypatch):
         def raise_fnf(*args, **kwargs):
-            raise FileNotFoundError("gh")
+            raise FileNotFoundError("claude")
 
         monkeypatch.setattr(gpn.subprocess, "run", raise_fnf)
-        assert gpn._call_gh_models("title") is None
+        assert gpn._call_llm("title") is None
 
     def test_success_returns_stdout_stripped(self, monkeypatch):
         class FakeResult:
@@ -147,19 +148,108 @@ class TestCallGhModels:
             stderr = ""
 
         monkeypatch.setattr(gpn.subprocess, "run", lambda *a, **kw: FakeResult())
-        assert gpn._call_gh_models("title") == "food-delivery-refund"
+        assert gpn._call_llm("title") == "food-delivery-refund"
+
+
+class TestCallLlmGitHubModels:
+    """GITHUB_TOKEN がある環境で GitHub Models Inference API を使う経路のテスト."""
+
+    @pytest.fixture(autouse=True)
+    def set_token(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+
+    def test_success_returns_content(self, monkeypatch):
+        class FakeMessage:
+            content = "  subscription-cancel-tracker  "
+
+        class FakeChoice:
+            message = FakeMessage()
+
+        class FakeResponse:
+            choices = [FakeChoice()]
+
+        class FakeCompletions:
+            def create(self, **kwargs):
+                return FakeResponse()
+
+        class FakeChat:
+            completions = FakeCompletions()
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                self.chat = FakeChat()
+
+        import sys
+        import types
+
+        fake_openai = types.ModuleType("openai")
+        fake_openai.OpenAI = FakeClient
+        monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+        assert gpn._call_llm("解約管理") == "subscription-cancel-tracker"
+
+    def test_empty_content_returns_none(self, monkeypatch):
+        class FakeMessage:
+            content = ""
+
+        class FakeChoice:
+            message = FakeMessage()
+
+        class FakeResponse:
+            choices = [FakeChoice()]
+
+        class FakeCompletions:
+            def create(self, **kwargs):
+                return FakeResponse()
+
+        class FakeChat:
+            completions = FakeCompletions()
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                self.chat = FakeChat()
+
+        import sys
+        import types
+
+        fake_openai = types.ModuleType("openai")
+        fake_openai.OpenAI = FakeClient
+        monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+        assert gpn._call_llm("title") is None
+
+    def test_api_error_returns_none(self, monkeypatch):
+        class FakeCompletions:
+            def create(self, **kwargs):
+                raise RuntimeError("API down")
+
+        class FakeChat:
+            completions = FakeCompletions()
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                self.chat = FakeChat()
+
+        import sys
+        import types
+
+        fake_openai = types.ModuleType("openai")
+        fake_openai.OpenAI = FakeClient
+        monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+        assert gpn._call_llm("title") is None
 
 
 class TestCli:
     def test_main_prints_generated_name(self, monkeypatch, capsys):
-        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: "subscription-cancel-tracker")
+        monkeypatch.setattr(gpn, "_call_llm", lambda title, timeout=30: "subscription-cancel-tracker")
         rc = gpn.main(["--title", "Uber Eats 解約", "--issue-number", "104"])
         assert rc == 0
         captured = capsys.readouterr()
         assert captured.out.strip() == "subscription-cancel-tracker"
 
     def test_main_prints_fallback_on_failure(self, monkeypatch, capsys):
-        monkeypatch.setattr(gpn, "_call_gh_models", lambda title, timeout=30: None)
+        monkeypatch.setattr(gpn, "_call_llm", lambda title, timeout=30: None)
         rc = gpn.main(["--title", "something", "--issue-number", "104"])
         assert rc == 0
         captured = capsys.readouterr()


### PR DESCRIPTION
## 背景

`/approve` 時の mvp-factory 用プロダクト名生成が `gh models run` CLI を叩いていたが、GitHub Actions ランナーには `gh-models` 拡張が未インストールで以下のエラーが発生していた:

```
ERROR __main__: gh models run 失敗 (rc=1, stderr=unknown command "models" for "gh"
新規生成した product_name: mvp-117  ← フォールバック
```

その結果 #117 で `kaionn/mvp-117` が作成されてしまった（`kaionn/subscription-guard` に手動リネーム済み）。

## 変更内容

- `src/generate_product_name.py`: `gh models run` サブプロセス呼び出しを廃止し、`generate_spec.py` と同じ OpenAI SDK 経由（`https://models.github.ai/inference`）で GitHub Models を叩くように統一。`GITHUB_TOKEN` が無い場合は `claude` CLI にフォールバック
- `.github/workflows/approve.yml`: `permissions` に `models: read` を追加（GitHub Models API 呼び出しに必要）
- `tests/test_generate_product_name.py`: `_call_gh_models` → `_call_llm` への追従 + GitHub Models 経路のテスト追加
- `data/pipeline_state.json`: #117 の `product_name` を `mvp-117` → `subscription-guard` に変更、rename イベントを追記

## テスト

```
============================== 182 passed in 1.58s ==============================
```

## 関連

- Issue #117
- Repo: https://github.com/kaionn/subscription-guard