### PR TITLE
feat: rejected (NOT_PLANNED) Issue との類似 pain を再起票対象から除外

### DIFF
--- a/src/discord_notify.py
+++ b/src/discord_notify.py
@@ -63,6 +63,32 @@ def _post_bot_message(payload: dict) -> None:
     resp.raise_for_status()
 
 
+def notify_dedup_summary(stats: dict, date_str: str) -> None:
+    """日次 dedup サマリーを Discord (Webhook) に通知する.
+
+    rejected match で起票スキップした件数があるときに呼ばれる想定。
+    個別ペインの再通知ではなく、運用観測用の集計値として 1 メッセージにまとめる。
+    """
+    rejected = int(stats.get("rejected_match", 0))
+    open_match = int(stats.get("open_match", 0))
+    new_issues = int(stats.get("new_issues", 0))
+
+    payload = {
+        "content": (
+            f"📋 **{date_str} dedup サマリー**\n"
+            f"- 新規起票: {new_issues} 件\n"
+            f"- open Issue 重複（コメント追記）: {open_match} 件\n"
+            f"- rejected と類似で起票スキップ: {rejected} 件"
+        )
+    }
+
+    try:
+        _post_webhook(payload)
+        logger.info(f"Discord dedup サマリー送信: {date_str}")
+    except Exception as e:
+        logger.warning(f"Discord dedup サマリー失敗: {e}")
+
+
 def notify_issue_created(
     pain: dict, issue_number: int, issue_url: str
 ) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -217,8 +217,8 @@ def process_day(
     logger.info(f"レポートを保存: {output_path}")
     logger.info(f"ペイン件数: {len(pains)} 件")
 
-    # LINE Notify で TOP3 を通知
-    notify.send_top_pains(pains, date_str)
+    # LINE Notify で TOP3 を通知（戻り値は dedup 統計）
+    dedup_stats = notify.send_top_pains(pains, date_str)
 
     # 高ポテンシャルなペインのディープダイブレポートを自動生成
     logger.info("--- ディープダイブ ---")
@@ -229,10 +229,15 @@ def process_day(
     generate_spec.run_for_latest(date_str)
 
     # 日次サマリー生成
-    _write_daily_summary(date_str, sources, pains)
+    _write_daily_summary(date_str, sources, pains, dedup_stats)
 
 
-def _write_daily_summary(date_str: str, sources: dict[str, list[dict]], pains: list[dict]) -> None:
+def _write_daily_summary(
+    date_str: str,
+    sources: dict[str, list[dict]],
+    pains: list[dict],
+    dedup_stats: dict | None = None,
+) -> None:
     """日次サマリーを生成し、GitHub Actions Job Summary に出力する."""
     source_lines = ", ".join(f"{name} {len(posts)}件" for name, posts in sources.items())
     total_posts = sum(len(v) for v in sources.values())
@@ -245,6 +250,12 @@ def _write_daily_summary(date_str: str, sources: dict[str, list[dict]], pains: l
     whitespace = sum(1 for p in pains if p.get("market_signal") == "whitespace")
     underserved = sum(1 for p in pains if p.get("market_signal") == "underserved")
 
+    # dedup サマリー（送信されない場合は 0 件として表示）
+    stats = dedup_stats or {}
+    new_issues = stats.get("new_issues", 0)
+    open_match = stats.get("open_match", 0)
+    rejected_match = stats.get("rejected_match", 0)
+
     summary = (
         f"## 📊 Pain Collector Daily Summary ({date_str})\n\n"
         f"| 項目 | 値 |\n"
@@ -253,7 +264,10 @@ def _write_daily_summary(date_str: str, sources: dict[str, list[dict]], pains: l
         f"| 抽出ペイン数 | {len(pains)} 件 |\n"
         f"| スコア S/A | {score_s}/{score_a} 件 |\n"
         f"| ホワイトスペース | {whitespace} 件 |\n"
-        f"| 低満足度市場 | {underserved} 件 |\n\n"
+        f"| 低満足度市場 | {underserved} 件 |\n"
+        f"| 新規起票 | {new_issues} 件 |\n"
+        f"| open 重複（コメント追記） | {open_match} 件 |\n"
+        f"| rejected 類似で起票スキップ | {rejected_match} 件 |\n\n"
         f"収集内訳: {source_lines}\n"
     )
 

--- a/src/notify.py
+++ b/src/notify.py
@@ -1,7 +1,9 @@
 """GitHub Issues でペインを個別 Issue として作成する（重複チェック付き）."""
 
+import datetime
 import json
 import logging
+import os
 import subprocess
 
 from sklearn.metrics.pairwise import cosine_similarity
@@ -28,6 +30,11 @@ WTP_LABELS = {
 DUPLICATE_THRESHOLD_HIGH = 0.7  # 確実に重複
 DUPLICATE_THRESHOLD_LOW = 0.4   # グレーゾーン（LLM で二次判定）
 
+# rejected (NOT_PLANNED / rejected label) issue をどこまで遡るか
+REJECTED_LOOKBACK_DAYS = 180
+REJECTED_FETCH_LIMIT = 500
+SKIPPED_PAINS_PATH = "raw/skipped_pains.jsonl"
+
 
 def _fetch_open_issues() -> list[dict]:
     """open 状態の Issue タイトル一覧を取得する."""
@@ -49,6 +56,91 @@ def _fetch_open_issues() -> list[dict]:
     except Exception:
         pass
     return []
+
+
+def _filter_rejected_issues(issues: list[dict]) -> list[dict]:
+    """closed Issue リストから「再起票 NG」扱いするものを抽出する.
+
+    判定条件:
+    - closedAt が直近 REJECTED_LOOKBACK_DAYS 日以内
+    - stateReason == "NOT_PLANNED" または rejected ラベル付き
+    """
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        days=REJECTED_LOOKBACK_DAYS
+    )
+    rejected: list[dict] = []
+    for iss in issues:
+        closed_at_str = iss.get("closedAt")
+        if not closed_at_str:
+            continue
+        try:
+            closed_at = datetime.datetime.fromisoformat(
+                closed_at_str.replace("Z", "+00:00")
+            )
+        except (ValueError, AttributeError):
+            continue
+        if closed_at < cutoff:
+            continue
+        state_reason = iss.get("stateReason", "")
+        labels = [
+            (lb.get("name", "") if isinstance(lb, dict) else lb)
+            for lb in iss.get("labels", []) or []
+        ]
+        if state_reason == "NOT_PLANNED" or "rejected" in labels:
+            rejected.append(iss)
+    return rejected
+
+
+def _fetch_rejected_issues() -> list[dict]:
+    """closed (NOT_PLANNED) または rejected ラベル付きの pain-report Issue を返す."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--label", "pain-report",
+                "--state", "closed",
+                "--json", "number,title,closedAt,stateReason,labels",
+                "--limit", str(REJECTED_FETCH_LIMIT),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            return []
+        issues = json.loads(result.stdout)
+    except Exception:
+        return []
+    return _filter_rejected_issues(issues)
+
+
+def _record_skipped_pain(
+    pain: dict,
+    matched_issue: dict,
+    date_str: str,
+    path: str | None = None,
+) -> None:
+    """rejected match でスキップしたペインを jsonl に記録する."""
+    target_path = path or SKIPPED_PAINS_PATH
+    record = {
+        "date": date_str,
+        "pain": pain.get("pain", ""),
+        "matched_issue_number": matched_issue.get("number"),
+        "matched_issue_title": matched_issue.get("title", ""),
+        "source_url": pain.get("source_url", ""),
+        "source_title": pain.get("source_title", ""),
+    }
+    try:
+        parent = os.path.dirname(target_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(target_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        logger.info(
+            f"スキップ記録: #{matched_issue.get('number')} と類似 → {target_path}"
+        )
+    except Exception as e:
+        logger.warning(f"スキップ記録失敗: {e}")
 
 
 def _llm_judge_duplicate(pain_text: str, existing_title: str) -> bool:
@@ -117,27 +209,52 @@ def _find_duplicate(pain_text: str, existing_issues: list[dict]) -> dict | None:
 
 
 def send_top_pains(pains: list[dict], date_str: str, top_n: int = 3) -> None:
-    """深刻度が高いペイン TOP N を個別の GitHub Issue として作成する."""
+    """深刻度が高いペイン TOP N を個別の GitHub Issue として作成する.
+
+    重複判定は open Issue + 直近 REJECTED_LOOKBACK_DAYS 日に rejected (NOT_PLANNED
+    または rejected ラベル) で close された Issue の両方を対象に行う。
+    rejected match した場合は新規起票せず raw/skipped_pains.jsonl に記録のみ残す。
+    """
     if not pains:
         return
 
-    existing_issues = _fetch_open_issues()
-    logger.info(f"既存 open Issue: {len(existing_issues)} 件")
+    open_issues = _fetch_open_issues()
+    rejected_issues = _fetch_rejected_issues()
+    logger.info(
+        f"既存 open Issue: {len(open_issues)} 件 / rejected Issue: {len(rejected_issues)} 件"
+    )
+
+    combined: list[dict] = []
+    for iss in open_issues:
+        combined.append({**iss, "_match_kind": "open"})
+    for iss in rejected_issues:
+        combined.append({**iss, "_match_kind": "rejected"})
 
     sorted_pains = sorted(pains, key=lambda x: x.get("severity", 0), reverse=True)
     top = sorted_pains[:top_n]
 
     for pain in top:
         pain_text = pain.get("pain", "")
-        duplicate = _find_duplicate(pain_text, existing_issues)
+        duplicate = _find_duplicate(pain_text, combined)
 
-        if duplicate:
-            logger.info(f"重複検出 → #{duplicate['number']} {duplicate['title'][:50]}")
-            _comment_duplicate(duplicate["number"], pain, date_str)
-        else:
+        if duplicate is None:
             issue = _create_issue(pain, date_str)
             if issue:
-                existing_issues.append(issue)
+                combined.append({**issue, "_match_kind": "open"})
+            continue
+
+        kind = duplicate.get("_match_kind", "open")
+        if kind == "rejected":
+            logger.info(
+                f"再起票スキップ: #{duplicate['number']} (rejected) "
+                f"{duplicate['title'][:50]}"
+            )
+            _record_skipped_pain(pain, duplicate, date_str)
+        else:
+            logger.info(
+                f"重複検出 → #{duplicate['number']} {duplicate['title'][:50]}"
+            )
+            _comment_duplicate(duplicate["number"], pain, date_str)
 
 
 def _comment_duplicate(issue_number: int, pain: dict, date_str: str) -> None:

--- a/src/notify.py
+++ b/src/notify.py
@@ -34,6 +34,7 @@ DUPLICATE_THRESHOLD_LOW = 0.4   # グレーゾーン（LLM で二次判定）
 REJECTED_LOOKBACK_DAYS = 180
 REJECTED_FETCH_LIMIT = 500
 SKIPPED_PAINS_PATH = "raw/skipped_pains.jsonl"
+DEDUP_METRICS_PATH = "data/dedup_metrics.json"
 
 
 def _fetch_open_issues() -> list[dict]:
@@ -143,6 +144,47 @@ def _record_skipped_pain(
         logger.warning(f"スキップ記録失敗: {e}")
 
 
+def _record_dedup_metrics(
+    date_str: str,
+    stats: dict,
+    path: str | None = None,
+) -> None:
+    """日次の dedup 集計（open/rejected match 件数 + 新規起票件数）を記録する.
+
+    既存の data/dedup_metrics.json を読み込み、date_str をキーに上書きする。
+    1 日複数回実行された場合は最後の呼び出しの値で更新される。
+    """
+    target_path = path or DEDUP_METRICS_PATH
+    try:
+        if os.path.exists(target_path):
+            with open(target_path, encoding="utf-8") as f:
+                data = json.load(f)
+                if not isinstance(data, dict):
+                    data = {}
+        else:
+            data = {}
+    except Exception:
+        data = {}
+
+    data[date_str] = {
+        "open_match": int(stats.get("open_match", 0)),
+        "rejected_match": int(stats.get("rejected_match", 0)),
+        "new_issues": int(stats.get("new_issues", 0)),
+    }
+
+    try:
+        parent = os.path.dirname(target_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(target_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=True)
+        logger.info(
+            f"dedup metrics 記録: {date_str} → {data[date_str]} ({target_path})"
+        )
+    except Exception as e:
+        logger.warning(f"dedup metrics 記録失敗: {e}")
+
+
 def _llm_judge_duplicate(pain_text: str, existing_title: str) -> bool:
     """LLM でグレーゾーンの重複を二次判定する."""
     import os
@@ -208,15 +250,18 @@ def _find_duplicate(pain_text: str, existing_issues: list[dict]) -> dict | None:
     return None
 
 
-def send_top_pains(pains: list[dict], date_str: str, top_n: int = 3) -> None:
+def send_top_pains(pains: list[dict], date_str: str, top_n: int = 3) -> dict:
     """深刻度が高いペイン TOP N を個別の GitHub Issue として作成する.
 
     重複判定は open Issue + 直近 REJECTED_LOOKBACK_DAYS 日に rejected (NOT_PLANNED
     または rejected ラベル) で close された Issue の両方を対象に行う。
     rejected match した場合は新規起票せず raw/skipped_pains.jsonl に記録のみ残す。
+
+    戻り値: {"open_match": int, "rejected_match": int, "new_issues": int}
     """
+    stats = {"open_match": 0, "rejected_match": 0, "new_issues": 0}
     if not pains:
-        return
+        return stats
 
     open_issues = _fetch_open_issues()
     rejected_issues = _fetch_rejected_issues()
@@ -241,6 +286,7 @@ def send_top_pains(pains: list[dict], date_str: str, top_n: int = 3) -> None:
             issue = _create_issue(pain, date_str)
             if issue:
                 combined.append({**issue, "_match_kind": "open"})
+                stats["new_issues"] += 1
             continue
 
         kind = duplicate.get("_match_kind", "open")
@@ -250,11 +296,24 @@ def send_top_pains(pains: list[dict], date_str: str, top_n: int = 3) -> None:
                 f"{duplicate['title'][:50]}"
             )
             _record_skipped_pain(pain, duplicate, date_str)
+            stats["rejected_match"] += 1
         else:
             logger.info(
                 f"重複検出 → #{duplicate['number']} {duplicate['title'][:50]}"
             )
             _comment_duplicate(duplicate["number"], pain, date_str)
+            stats["open_match"] += 1
+
+    _record_dedup_metrics(date_str, stats)
+
+    if stats["rejected_match"] > 0:
+        try:
+            from . import discord_notify
+            discord_notify.notify_dedup_summary(stats, date_str)
+        except Exception as e:
+            logger.warning(f"Discord dedup サマリー通知失敗: {e}")
+
+    return stats
 
 
 def _comment_duplicate(issue_number: int, pain: dict, date_str: str) -> None:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -14,6 +14,7 @@ from src.notify import (
     REJECTED_LOOKBACK_DAYS,
     _filter_rejected_issues,
     _find_duplicate,
+    _record_dedup_metrics,
     _record_skipped_pain,
 )
 
@@ -264,3 +265,66 @@ class TestRecordSkippedPain:
         matched = {"number": 1, "title": "y"}
         _record_skipped_pain(pain, matched, "2026-04-28", str(path))
         assert path.exists()
+
+
+class TestRecordDedupMetrics:
+    """_record_dedup_metrics のテスト."""
+
+    def test_writes_new_metrics_file(self, tmp_path):
+        """新規ファイルに stats を date_str キーで書き込む."""
+        path = tmp_path / "dedup_metrics.json"
+        stats = {"open_match": 2, "rejected_match": 5, "new_issues": 1}
+        _record_dedup_metrics("2026-04-28", stats, str(path))
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "2026-04-28" in data
+        assert data["2026-04-28"]["open_match"] == 2
+        assert data["2026-04-28"]["rejected_match"] == 5
+        assert data["2026-04-28"]["new_issues"] == 1
+
+    def test_appends_to_existing_metrics(self, tmp_path):
+        """既存ファイルに別 date_str を追加する（過去データを保持）."""
+        path = tmp_path / "dedup_metrics.json"
+        path.write_text(
+            json.dumps({"2026-04-27": {"open_match": 1, "rejected_match": 0, "new_issues": 3}}),
+            encoding="utf-8",
+        )
+        stats = {"open_match": 0, "rejected_match": 2, "new_issues": 1}
+        _record_dedup_metrics("2026-04-28", stats, str(path))
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "2026-04-27" in data
+        assert "2026-04-28" in data
+        assert data["2026-04-27"]["new_issues"] == 3
+        assert data["2026-04-28"]["rejected_match"] == 2
+
+    def test_overwrites_same_date(self, tmp_path):
+        """同じ date_str で 2 回呼ばれた場合は後勝ちで上書きする."""
+        path = tmp_path / "dedup_metrics.json"
+        _record_dedup_metrics(
+            "2026-04-28",
+            {"open_match": 1, "rejected_match": 0, "new_issues": 0},
+            str(path),
+        )
+        _record_dedup_metrics(
+            "2026-04-28",
+            {"open_match": 0, "rejected_match": 5, "new_issues": 2},
+            str(path),
+        )
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["2026-04-28"]["rejected_match"] == 5
+        assert data["2026-04-28"]["open_match"] == 0
+
+    def test_recovers_from_corrupted_file(self, tmp_path):
+        """壊れた JSON を上書きして新規データを書く（クラッシュしない）."""
+        path = tmp_path / "dedup_metrics.json"
+        path.write_text("not a valid json {", encoding="utf-8")
+        _record_dedup_metrics(
+            "2026-04-28",
+            {"open_match": 1, "rejected_match": 1, "new_issues": 1},
+            str(path),
+        )
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["2026-04-28"]["open_match"] == 1

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -4,9 +4,18 @@
 TF-IDF による重複検出の純粋ロジックのみをテストする。
 """
 
+import json
+
 import pytest
 
-from src.notify import DUPLICATE_THRESHOLD_HIGH, DUPLICATE_THRESHOLD_LOW, _find_duplicate
+from src.notify import (
+    DUPLICATE_THRESHOLD_HIGH,
+    DUPLICATE_THRESHOLD_LOW,
+    REJECTED_LOOKBACK_DAYS,
+    _filter_rejected_issues,
+    _find_duplicate,
+    _record_skipped_pain,
+)
 
 
 class TestFindDuplicate:
@@ -100,3 +109,158 @@ class TestFindDuplicate:
         result = _find_duplicate(pain_text, existing)
         assert result is not None
         assert result["number"] == 5
+
+    def test_match_kind_open_propagated(self):
+        """open issue にマッチした場合、_match_kind が open として返る."""
+        existing = [
+            {"number": 1, "title": "毎日の家計管理が面倒で自動化したい", "_match_kind": "open"},
+        ]
+        result = _find_duplicate("毎日の家計管理が面倒で自動化したい", existing)
+        assert result is not None
+        assert result["number"] == 1
+        assert result.get("_match_kind") == "open"
+
+    def test_match_kind_rejected_propagated(self):
+        """rejected issue にマッチした場合、_match_kind が rejected として返る."""
+        existing = [
+            {"number": 99, "title": "全く関係ない別の話題", "_match_kind": "open"},
+            {"number": 100, "title": "毎日の家計管理が面倒で自動化したい", "_match_kind": "rejected"},
+        ]
+        result = _find_duplicate("毎日の家計管理が面倒で自動化したい", existing)
+        assert result is not None
+        assert result["number"] == 100
+        assert result.get("_match_kind") == "rejected"
+
+    def test_match_kind_default_open_when_missing(self):
+        """_match_kind が dict にない場合は補完されない（後方互換）.
+
+        既存呼び出し側は _match_kind を付けずに dict を渡すケースがある（テスト等）。
+        _find_duplicate は受け取った dict をそのまま返すだけで、kind の補完はしない。
+        呼び出し側が `.get("_match_kind", "open")` で補完する想定。
+        """
+        existing = [
+            {"number": 1, "title": "毎日の家計管理が面倒で自動化したい"},
+        ]
+        result = _find_duplicate("毎日の家計管理が面倒で自動化したい", existing)
+        assert result is not None
+        # _match_kind がない dict が返ったときは呼び出し側が "open" 扱い
+        assert result.get("_match_kind", "open") == "open"
+
+
+class TestFilterRejectedIssues:
+    """_filter_rejected_issues のテスト.
+
+    closedAt が cutoff 日数以内、かつ stateReason=NOT_PLANNED または
+    rejected ラベル付きの issue だけを返すこと。
+    """
+
+    def test_not_planned_within_window_included(self):
+        """NOT_PLANNED で直近の close は含める."""
+        from datetime import datetime, timedelta, timezone
+
+        recent = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+        issues = [
+            {
+                "number": 1,
+                "title": "foo",
+                "closedAt": recent,
+                "stateReason": "NOT_PLANNED",
+                "labels": [],
+            },
+        ]
+        result = _filter_rejected_issues(issues)
+        assert len(result) == 1
+        assert result[0]["number"] == 1
+
+    def test_completed_without_rejected_label_excluded(self):
+        """COMPLETED で rejected ラベルなしは含めない（done の作業は再起票許可）."""
+        from datetime import datetime, timedelta, timezone
+
+        recent = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+        issues = [
+            {
+                "number": 1,
+                "title": "foo",
+                "closedAt": recent,
+                "stateReason": "COMPLETED",
+                "labels": [{"name": "pain-report"}],
+            },
+        ]
+        result = _filter_rejected_issues(issues)
+        assert result == []
+
+    def test_completed_with_rejected_label_included(self):
+        """COMPLETED でも rejected ラベル付きは含める（手動却下対策）."""
+        from datetime import datetime, timedelta, timezone
+
+        recent = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+        issues = [
+            {
+                "number": 2,
+                "title": "bar",
+                "closedAt": recent,
+                "stateReason": "COMPLETED",
+                "labels": [{"name": "rejected"}],
+            },
+        ]
+        result = _filter_rejected_issues(issues)
+        assert len(result) == 1
+        assert result[0]["number"] == 2
+
+    def test_outside_lookback_window_excluded(self):
+        """cutoff より古い close は除外する."""
+        from datetime import datetime, timedelta, timezone
+
+        old = (
+            datetime.now(timezone.utc) - timedelta(days=REJECTED_LOOKBACK_DAYS + 30)
+        ).isoformat().replace("+00:00", "Z")
+        issues = [
+            {
+                "number": 1,
+                "title": "foo",
+                "closedAt": old,
+                "stateReason": "NOT_PLANNED",
+                "labels": [],
+            },
+        ]
+        result = _filter_rejected_issues(issues)
+        assert result == []
+
+    def test_missing_closed_at_excluded(self):
+        """closedAt がない issue は除外する."""
+        issues = [
+            {"number": 1, "title": "foo", "stateReason": "NOT_PLANNED", "labels": []},
+        ]
+        result = _filter_rejected_issues(issues)
+        assert result == []
+
+
+class TestRecordSkippedPain:
+    """_record_skipped_pain のテスト."""
+
+    def test_appends_jsonl_line(self, tmp_path, monkeypatch):
+        """指定パスに jsonl 形式で 1 行追記される."""
+        path = tmp_path / "skipped_pains.jsonl"
+        pain = {
+            "pain": "PayPay が起動しない",
+            "source_url": "https://example.com",
+            "source_title": "PayPay レビュー",
+        }
+        matched = {"number": 156, "title": "[テクノロジー] PayPay 起動不可"}
+
+        _record_skipped_pain(pain, matched, "2026-04-28", str(path))
+
+        content = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(content) == 1
+        record = json.loads(content[0])
+        assert record["pain"] == "PayPay が起動しない"
+        assert record["matched_issue_number"] == 156
+        assert record["date"] == "2026-04-28"
+
+    def test_creates_parent_dir_if_missing(self, tmp_path):
+        """親ディレクトリが存在しない場合は自動作成する."""
+        path = tmp_path / "nested" / "dir" / "skipped.jsonl"
+        pain = {"pain": "x"}
+        matched = {"number": 1, "title": "y"}
+        _record_skipped_pain(pain, matched, "2026-04-28", str(path))
+        assert path.exists()


### PR DESCRIPTION
## Summary

- close 済 (`stateReason=NOT_PLANNED` or `rejected` ラベル) の pain-report Issue を直近 180 日まで重複判定対象に追加
- TF-IDF cosine similarity >= 0.7 でマッチした場合は新規起票せず `raw/skipped_pains.jsonl` に記録のみ
- open Issue 重複時のコメント追記挙動は維持（破壊的変更なし）
- `data/dedup_metrics.json` に日次集計 `{open_match, rejected_match, new_issues}` を保存
- 日次サマリー（GH Actions Job Summary）に dedup 行を追加
- Discord にも `notify_dedup_summary` で集計通知（rejected match > 0 の日のみ）

## 背景

`/pick-idea` 等で MVP 候補として見送った pain は `not planned` で close しているが、現状のパイプラインでは PayPay 起動不可・マネーフォワード ME の連携エラー等、close 済の Issue と本質的に同じペインが翌日以降も繰り返し起票されていた。

既存の `_find_duplicate` は `--state open` のみを対象にしていたため、close 済との照合が抜けていたのが原因。重複検出インフラ（TF-IDF + LLM 二次判定 + fugashi 形態素解析）は揃っていたので、コーパスを拡張する方針で対応した。

## 変更内容

### `src/notify.py`
- 定数追加: `REJECTED_LOOKBACK_DAYS=180`, `REJECTED_FETCH_LIMIT=500`, `SKIPPED_PAINS_PATH`, `DEDUP_METRICS_PATH`
- `_filter_rejected_issues(issues)`: NOT_PLANNED または rejected ラベル + 直近 180 日でフィルタ
- `_fetch_rejected_issues()`: `gh issue list --state closed` で取得 → filter
- `_record_skipped_pain(pain, matched, date_str, path?)`: jsonl 形式で skip 履歴を保存
- `_record_dedup_metrics(date_str, stats, path?)`: data/dedup_metrics.json に日次集計
- `send_top_pains` を改修: open + rejected を `_match_kind` 付きで統合 → kind 分岐 → stats 返却

### `src/discord_notify.py`
- `notify_dedup_summary(stats, date_str)`: 集計値を Webhook で 1 メッセージ通知

### `src/main.py`
- `send_top_pains` の戻り値を受けて `_write_daily_summary` に渡す
- 日次サマリーに `新規起票 / open 重複 / rejected スキップ` 行を追加

### `tests/test_notify.py`
- 新規 14 件追加（match_kind 伝搬、rejected フィルタ、skipped jsonl、dedup metrics）
- 既存 9 件含めて 23 件すべて GREEN
- リポジトリ全体: 247/247 GREEN

## 設計判断

| 案 | 採用 | 理由 |
|---|---|---|
| 全 closed を対象 | ❌ | done/completed で close した Issue も対象になり、ユーザーが再考したいペインを潰す |
| stateReason=NOT_PLANNED + rejected ラベル | ✅ | 「明示的に却下した」ものだけを再起票 NG |
| `gh_client.list_issues` を拡張 | ❌ | notify.py 内で subprocess 直接呼び出しで完結。最小変更原則 |
| `_find_duplicate` の戻り値を tuple 化 | ❌ | 既存テスト多数破壊。dict に `_match_kind` キーを混ぜる方式で後方互換性確保 |

## Test plan

- [x] `pytest tests/` 全 247 件 GREEN
- [x] `_find_duplicate` の `_match_kind` 伝搬（open/rejected/欠落時の補完）
- [x] `_filter_rejected_issues` の境界（lookback 内外、stateReason の組み合わせ、closedAt 欠落）
- [x] `_record_skipped_pain` の親ディレクトリ自動作成
- [x] `_record_dedup_metrics` の新規/追記/上書き/壊れた JSON 復旧
- [ ] CI で `pip install -r requirements.txt && pytest` が GREEN
- [ ] 翌日のパイプライン実行で実際に rejected match されるかログ確認（運用観測）

## 関連 URL

closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)