### PR TITLE
DISCORD_BOT_TOKEN を DIARY_BOT_TOKEN に改名

### DIFF
--- a/src/discord_notify.py
+++ b/src/discord_notify.py
@@ -48,7 +48,7 @@ def _post_webhook(payload: dict) -> None:
 
 def _post_bot_message(payload: dict) -> None:
     """Discord Bot API でチャンネルにメッセージを送信する."""
-    token = os.environ.get("DISCORD_BOT_TOKEN", "")
+    token = os.environ.get("DIARY_BOT_TOKEN", "")
     channel_id = os.environ.get("DISCORD_CHANNEL_ID", "")
     if not token or not channel_id:
         return
@@ -130,7 +130,7 @@ def notify_mvp_picked(
         return
 
     bot_available = bool(
-        os.environ.get("DISCORD_BOT_TOKEN") and os.environ.get("DISCORD_CHANNEL_ID")
+        os.environ.get("DIARY_BOT_TOKEN") and os.environ.get("DISCORD_CHANNEL_ID")
     )
 
     rank_emoji = ["🥇", "🥈", "🥉"]

--- a/tests/test_discord_notify.py
+++ b/tests/test_discord_notify.py
@@ -64,21 +64,21 @@ class TestPostWebhook:
 
 class TestPostBotMessage:
     def test_skips_when_no_token(self, monkeypatch):
-        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("DIARY_BOT_TOKEN", raising=False)
         monkeypatch.setenv("DISCORD_CHANNEL_ID", "123")
         with patch("src.discord_notify.create_retry_session") as mock_session:
             _post_bot_message({"content": "test"})
             mock_session.assert_not_called()
 
     def test_skips_when_no_channel_id(self, monkeypatch):
-        monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
+        monkeypatch.setenv("DIARY_BOT_TOKEN", "token")
         monkeypatch.delenv("DISCORD_CHANNEL_ID", raising=False)
         with patch("src.discord_notify.create_retry_session") as mock_session:
             _post_bot_message({"content": "test"})
             mock_session.assert_not_called()
 
     def test_posts_with_bot_auth(self, monkeypatch):
-        monkeypatch.setenv("DISCORD_BOT_TOKEN", "my-bot-token")
+        monkeypatch.setenv("DIARY_BOT_TOKEN", "my-bot-token")
         monkeypatch.setenv("DISCORD_CHANNEL_ID", "999888777")
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
@@ -177,7 +177,7 @@ class TestNotifyMvpPicked:
 
     def test_bot_api_sends_individual_messages(self, monkeypatch):
         """Bot API 利用時は候補ごとに個別メッセージを送信する."""
-        monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
+        monkeypatch.setenv("DIARY_BOT_TOKEN", "token")
         monkeypatch.setenv("DISCORD_CHANNEL_ID", "123")
         call_count = {"n": 0}
 
@@ -197,7 +197,7 @@ class TestNotifyMvpPicked:
 
     def test_approve_button_only_when_spec_exists(self, monkeypatch):
         """Spec ありの候補のみ Approve ボタンが付く."""
-        monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
+        monkeypatch.setenv("DIARY_BOT_TOKEN", "token")
         monkeypatch.setenv("DISCORD_CHANNEL_ID", "123")
         payloads = []
 
@@ -228,7 +228,7 @@ class TestNotifyMvpPicked:
     def test_webhook_fallback_when_no_bot(self, monkeypatch):
         """Bot 未設定時は Webhook にフォールバックする."""
         monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://example.com/webhook")
-        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("DIARY_BOT_TOKEN", raising=False)
         monkeypatch.delenv("DISCORD_CHANNEL_ID", raising=False)
         captured = {}
 
@@ -256,7 +256,7 @@ class TestNotifyMvpPicked:
 
     def test_bot_fallback_to_webhook_on_error(self, monkeypatch):
         """Bot API 失敗時は Webhook にフォールバックする."""
-        monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
+        monkeypatch.setenv("DIARY_BOT_TOKEN", "token")
         monkeypatch.setenv("DISCORD_CHANNEL_ID", "123")
         monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://example.com/webhook")
         call_urls = []


### PR DESCRIPTION
## 背景

`~/.config/zsh/1password.zsh` で diary-bot 用のトークンを generic 名 `DISCORD_BOT_TOKEN` で export していたため、別プロジェクト (amadeus-ui) で同名の env 変数を使うと衝突する問題があった。bot ごとに識別可能な名前空間にするため `DIARY_BOT_TOKEN` に改名する。

## 変更内容

- `src/discord_notify.py`: `os.environ.get("DISCORD_BOT_TOKEN")` → `DIARY_BOT_TOKEN` (2 箇所)
- `tests/test_discord_notify.py`: monkeypatch の env 名を更新 (7 箇所)

## 関連変更 (別 repo)

- chezmoi: `dot_config/zsh/1password.zsh` で export 名を `DIARY_BOT_TOKEN` に改名 (commit `080e58b`)
- a0ba-diary-blog: CLAUDE.md ドキュメント更新
- GitHub Secret: `DISCORD_BOT_TOKEN` → `DIARY_BOT_TOKEN` (kaionn/pain-collector)

## テスト

`python -m pytest tests/test_discord_notify.py` → 17 passed