### PR TITLE
/probe コマンド追加: mvp-factory 直行を廃止し Signal Lab の検証 LP 生成に切り替え

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,17 +1,17 @@
-name: Approve and Build MVP
+name: Approve and Build MVP (deprecated)
 
 on:
   issue_comment:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
-  models: read
 
 jobs:
   check-approve:
     # /approve コメントかつ pain-report ラベル付き Issue のみ
+    # mvp-factory への自動 build dispatch は廃止済み。/probe (Signal Lab) への案内のみ行う。
     if: |
       github.event.comment.body == '/approve' &&
       contains(github.event.issue.labels.*.name, 'pain-report')
@@ -22,25 +22,7 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv sync
-
-      - name: Sync latest pipeline_state.json from GitHub API
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # /spec 直後の /approve でも race を避けるため、リモートの最新を取り直す
-          uv run python -m src.state_sync fetch \
-            --repo "${{ github.repository }}" \
-            --remote-path data/pipeline_state.json \
-            --local-path data/pipeline_state.json
-
       - name: Validate approver
-        id: validate-approver
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -49,108 +31,15 @@ jobs:
           OWNER=$(gh repo view --json owner -q '.owner.login')
           if [ "$COMMENTER" != "$OWNER" ]; then
             echo "::warning::Unauthorized approver: $COMMENTER"
-            gh issue comment "$ISSUE_NUMBER" --body "⚠️ リポジトリオーナーのみ承認できます。"
+            gh issue comment "$ISSUE_NUMBER" --body "⚠️ リポジトリオーナーのみ実行できます。"
             exit 1
           fi
 
-      - name: Validate picked & spec
-        id: validate-spec
+      - name: Guide to /probe
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          PICKED_CHECK=$(uv run python -m src.approve_checks picked-check \
-            --state data/pipeline_state.json \
-            --issue-number "$ISSUE_NUMBER")
+          gh issue comment "$ISSUE_NUMBER" --body "🚧 \`/approve\` は廃止されました（mvp-factory はアーカイブ予定なのだ）。
 
-          if [ "$PICKED_CHECK" = "NO_STATE" ] || [ "$PICKED_CHECK" = "NOT_PICKED" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ この Issue は picked されていません。先に \`/pick\` → \`/spec\` を実行してください。"
-            exit 1
-          fi
-
-          if [ "$PICKED_CHECK" = "NO_SPEC" ] || [ ! -f "$PICKED_CHECK" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Spec ファイルが見つかりません。\`/spec\` を実行してから再度 \`/approve\` してください。"
-            exit 1
-          fi
-
-          SPEC_FILE="$PICKED_CHECK"
-
-          echo "spec_file=$SPEC_FILE" >> "$GITHUB_OUTPUT"
-          echo "✅ Spec found: $SPEC_FILE"
-
-      - name: Resolve product name
-        id: product-name
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          # 既存 state に product_name が保存されていれば再利用（冪等化）
-          EXISTING=$(uv run python -m src.approve_checks resolve-product-name \
-            --state data/pipeline_state.json \
-            --issue-number "$ISSUE_NUMBER")
-
-          if [ -n "$EXISTING" ]; then
-            echo "既存の product_name を再利用: $EXISTING"
-            PRODUCT_NAME="$EXISTING"
-          else
-            TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')
-            PRODUCT_NAME=$(uv run python -m src.generate_product_name \
-              --title "$TITLE" \
-              --issue-number "$ISSUE_NUMBER")
-            echo "新規生成した product_name: $PRODUCT_NAME"
-          fi
-
-          echo "product_name=$PRODUCT_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Update state (status=building, product_name)
-        env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          PRODUCT_NAME: ${{ steps.product-name.outputs.product_name }}
-        run: |
-          gh issue edit "$ISSUE_NUMBER" --add-label "building"
-          gh issue comment "$ISSUE_NUMBER" \
-            --body "🚀 承認されました。自動実装を開始します...
-          プロダクト名: \`$PRODUCT_NAME\`（リポジトリ: kaionn/$PRODUCT_NAME）"
-
-          uv run python -m src.approve_checks update-state \
-            --state data/pipeline_state.json \
-            --issue-number "$ISSUE_NUMBER" \
-            --status building \
-            --product-name "$PRODUCT_NAME"
-
-          # pipeline_state.json を GitHub API で直接更新（Branch Protection バイパス）
-          uv run python -m src.state_sync push \
-            --repo "${{ github.repository }}" \
-            --remote-path data/pipeline_state.json \
-            --local-path data/pipeline_state.json \
-            --message "pipeline: #$ISSUE_NUMBER を building に更新 (product=$PRODUCT_NAME)" \
-            --create-if-missing
-
-      - name: Trigger mvp-factory build
-        env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          PRODUCT_NAME: ${{ steps.product-name.outputs.product_name }}
-        run: |
-          # Spec ファイルの内容を base64 エンコードして渡す
-          SPEC_CONTENT=$(base64 < "${{ steps.validate-spec.outputs.spec_file }}")
-
-          # Deep Dive があれば同様に渡す
-          DEEP_DIVE_CONTENT=""
-          DEEP_DIVE_PATH=$(uv run python -m src.approve_checks deep-dive-path \
-            --state data/pipeline_state.json \
-            --issue-number "$ISSUE_NUMBER")
-          if [ -n "$DEEP_DIVE_PATH" ] && [ -f "$DEEP_DIVE_PATH" ]; then
-            DEEP_DIVE_CONTENT=$(base64 < "$DEEP_DIVE_PATH")
-          fi
-
-          gh workflow run build.yml \
-            --repo kaionn/mvp-factory \
-            -f issue_number="$ISSUE_NUMBER" \
-            -f source_repo="${{ github.repository }}" \
-            -f spec_content="$SPEC_CONTENT" \
-            -f deep_dive_content="$DEEP_DIVE_CONTENT" \
-            -f product_name="$PRODUCT_NAME"
-
-          echo "✅ mvp-factory の build.yml を dispatch しました（product: $PRODUCT_NAME）"
+          新機構では \`/probe\` で Signal Lab に検証用 LP を生成し、需要シグナルを見てから本実装するのだ。→ \`/probe\` を実行してほしいのだ。"

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -11,13 +11,14 @@ permissions:
 
 jobs:
   dispatch:
-    # /pick /spec /status /reject /help いずれかで開始 + pain-report ラベル付き Issue のみ
+    # /pick /spec /status /probe /reject /help いずれかで開始 + pain-report ラベル付き Issue のみ
     if: |
       contains(github.event.issue.labels.*.name, 'pain-report') &&
       (
         startsWith(github.event.comment.body, '/pick') ||
         startsWith(github.event.comment.body, '/spec') ||
         startsWith(github.event.comment.body, '/status') ||
+        startsWith(github.event.comment.body, '/probe') ||
         startsWith(github.event.comment.body, '/reject') ||
         startsWith(github.event.comment.body, '/help')
       )
@@ -65,6 +66,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # /probe の signal-lab への workflow dispatch にのみ使用（他リポジトリへの
+          # dispatch は GITHUB_TOKEN では権限不足なため、その呼び出しだけ GH_TOKEN を上書きする）
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/src/gh_client.py
+++ b/src/gh_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,8 @@ HELP_BLOCK = f"""{HELP_MARKER}
 | `/spec` | Issue 本文から Spec を生成（未 pick なら自動 pick） |
 | `/spec --force` | 既存 Spec を上書き再生成 |
 | `/status` | picked / spec / deep_dive の現状と履歴を返答 |
-| `/approve` | Spec 生成後、mvp-factory で自動実装を開始 |
+| `/probe` | Signal Lab で検証用 LP を生成し需要シグナルを計測（未 pick なら自動 pick） |
+| `/approve` | (廃止・`/probe` へ) |
 | `/reject` | picked から削除 |
 | `/help` | このヘルプを Issue 本文に追加・更新 |
 
@@ -119,6 +121,37 @@ def remove_labels(issue_number: int, labels: list[str]) -> bool:
         return True
     except Exception as e:
         logger.warning(f"ラベル削除失敗 #{issue_number}: {e}")
+        return False
+
+
+def trigger_workflow(
+    repo: str,
+    workflow: str,
+    inputs: dict[str, str],
+    *,
+    token: str | None = None,
+) -> bool:
+    """他リポジトリの workflow_dispatch をトリガーする. 成功なら True.
+
+    既定の ``GITHUB_TOKEN`` は他リポジトリへの dispatch を許可しないため、
+    ``token``（PAT_TOKEN 等）を渡すとその値で GH_TOKEN を上書きして実行する。
+    """
+    cmd = ["gh", "workflow", "run", workflow, "--repo", repo]
+    for key, value in inputs.items():
+        cmd.extend(["-f", f"{key}={value}"])
+
+    env = {**os.environ, "GH_TOKEN": token} if token else None
+
+    try:
+        subprocess.run(
+            cmd, capture_output=True, text=True, timeout=30, check=True, env=env,
+        )
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.warning(f"workflow dispatch 失敗 ({workflow} @ {repo}): {e.stderr[:200] if e.stderr else e}")
+        return False
+    except Exception as e:
+        logger.warning(f"workflow dispatch 失敗 ({workflow} @ {repo}): {e}")
         return False
 
 

--- a/src/issue_commands.py
+++ b/src/issue_commands.py
@@ -1,12 +1,13 @@
 """Issue コメントから操作するコマンド群.
 
 GitHub Actions の issue_comment トリガーから呼び出され、
-スコアラベルや日次パイプラインに依存せず単体で Issue を pick → spec → approve まで進められる。
+スコアラベルや日次パイプラインに依存せず単体で Issue を pick → spec → probe まで進められる。
 
 サブコマンド:
 - pick     : pipeline_state.json の picked[] にこの Issue を追加
 - spec     : Issue 本文から Spec を生成し、picked[] の spec を更新（--force で再生成）
 - status   : この Issue の picked / spec / deep_dive 状態を返却
+- probe    : Signal Lab（kaionn/signal-lab）へ検証用 LP 生成を dispatch する
 - reject   : picked[] からこの Issue を削除
 - help     : コマンド一覧を返す（既存 Issue で覚えがない時用）
 
@@ -19,14 +20,18 @@ GitHub Actions の issue_comment トリガーから呼び出され、
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import logging
 import os
+import re
 import shlex
 from datetime import datetime, timezone, timedelta
 
+from . import generate_product_name
 from . import generate_spec
 from . import gh_client
+from . import notify
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -39,6 +44,10 @@ JST = timezone(timedelta(hours=9))
 LABEL_PICKED = "📌picked"
 LABEL_SPEC_READY = "📐spec-ready"
 LABEL_BUILDING = "building"
+LABEL_PROBING = "🧪probing"
+
+SIGNAL_LAB_REPO = "kaionn/signal-lab"
+SIGNAL_LAB_WORKFLOW = "probe-request.yml"
 
 HELP_TEXT = gh_client.HELP_BLOCK
 
@@ -191,7 +200,7 @@ def cmd_pick(issue_number: int, args: list[str] | None = None) -> int:
         "✅ MVP 候補として pick されたのだ。\n\n"
         "次のステップ:\n"
         "- `/spec` で Spec を生成\n"
-        "- Spec 生成後に `/approve` で自動実装トリガー\n"
+        "- `/probe` で Signal Lab に検証用 LP を生成依頼\n"
         "- 取り消すには `/reject`",
     )
     _notify_discord(f"📌 picked: #{issue_number} {entry['title'][:60]}")
@@ -262,9 +271,152 @@ def cmd_spec(issue_number: int, args: list[str] | None = None) -> int:
     gh_client.post_comment(
         issue_number,
         f"✅ Spec を生成したのだ: `{rel_path}`\n\n"
-        f"次は `/approve` コメントで自動実装が走るのだ。",
+        f"次は `/probe` コメントで Signal Lab に検証用 LP 生成を依頼できるのだ。",
     )
     _notify_discord(f"📐 spec-ready: #{issue_number} → {rel_path}")
+    return 0
+
+
+_SOURCE_SECTION_RE = re.compile(r"## ソース\n+\[(.*?)\]\((https?://[^\s)]+)\)")
+_MARKET_SECTION_RE = re.compile(r"## 市場シグナル\n(.*?)(?:\n##|\Z)", re.DOTALL)
+_MARKET_APP_RE = re.compile(
+    r"- \[(?P<name>.*?)\]\((?P<url>https?://[^\s)]+)\) "
+    r"⭐(?P<rating>[^\s(]+) \((?P<reviews>\d+)件\) (?P<price>.+)"
+)
+
+
+def _first_sentence(text: str) -> str:
+    """先頭の一文（句点区切り）を取り出す。無ければ先頭行を短縮して返す."""
+    stripped = text.strip()
+    if not stripped:
+        return ""
+    first_line = stripped.split("\n", 1)[0].strip()
+    if "。" in first_line:
+        return first_line.split("。", 1)[0] + "。"
+    return first_line[:120]
+
+
+def _extract_source(body: str) -> tuple[str | None, str | None]:
+    """Issue 本文の `## ソース` セクションから (source_url, source_title) を抽出する."""
+    m = _SOURCE_SECTION_RE.search(body)
+    if not m:
+        return None, None
+    title, url = m.group(1), m.group(2)
+    return url, title
+
+
+def _extract_market_apps(body: str) -> list[dict]:
+    """Issue 本文の `## 市場シグナル` セクションから競合アプリ一覧を抽出する."""
+    section_match = _MARKET_SECTION_RE.search(body)
+    if not section_match:
+        return []
+
+    apps = []
+    for m in _MARKET_APP_RE.finditer(section_match.group(1)):
+        apps.append({
+            "name": m.group("name"),
+            "url": m.group("url"),
+            "rating": m.group("rating"),
+            "reviews": int(m.group("reviews")),
+            "price": m.group("price").strip(),
+        })
+    return apps
+
+
+def _build_probe_payload(issue_number: int, title: str, body: str, product_name: str) -> dict:
+    """signal-lab の probe-request.yml へ渡すペイロードを構築する.
+
+    構造化データは notify.extract_pain_data_from_body（Issue 本文に埋め込まれた
+    pain-data メタデータ）を再利用し、そこに含まれない source_url / market_apps のみ
+    Issue 本文の該当セクションから抽出する。
+    """
+    pain_data = notify.extract_pain_data_from_body(body) or {
+        "pain": title,
+        "app_idea": "",
+        "existing_solutions": None,
+        "severity": 3,
+        "willingness_to_pay": "medium",
+    }
+
+    pain_text = pain_data.get("pain") or title
+    existing = pain_data.get("existing_solutions")
+    pain_full = f"{pain_text}\n\n既存ソリューション: {existing}" if existing else pain_text
+
+    idea = pain_data.get("app_idea") or ""
+    tagline = _first_sentence(idea) if idea else title
+
+    source_url, source_title = _extract_source(body)
+    market_apps = _extract_market_apps(body)
+
+    return {
+        "slug": product_name,
+        "title": product_name,
+        "tagline": tagline,
+        "pain": pain_full,
+        "idea": idea,
+        "source_url": source_url,
+        "source_title": source_title,
+        "market_apps": market_apps,
+        "severity": pain_data.get("severity", 3),
+        "monetization": pain_data.get("willingness_to_pay", "medium"),
+    }
+
+
+def cmd_probe(issue_number: int, args: list[str] | None = None) -> int:
+    """Signal Lab（kaionn/signal-lab）へ検証用 LP 生成を dispatch する."""
+    state = _load_state()
+    entry = _find_entry(state, issue_number)
+    if entry is None:
+        # 未 pick の場合は自動で pick も行う（/spec と同じ流儀）
+        cmd_pick(issue_number)
+        state = _load_state()
+        entry = _find_entry(state, issue_number)
+        if entry is None:
+            gh_client.post_comment(issue_number, "❌ pick に失敗したのだ。")
+            return 1
+
+    issue = gh_client.fetch_issue(issue_number)
+    title = issue.get("title", "")
+    body = issue.get("body", "") or ""
+
+    # 既存 product_name があれば再利用（冪等化。/approve と同じ方針）
+    product_name = entry.get("product_name") or generate_product_name.generate(title, issue_number)
+
+    payload = _build_probe_payload(issue_number, title, body, product_name)
+    encoded_payload = base64.b64encode(
+        json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    ).decode("ascii")
+
+    dispatched = gh_client.trigger_workflow(
+        SIGNAL_LAB_REPO,
+        SIGNAL_LAB_WORKFLOW,
+        {
+            "issue_number": str(issue_number),
+            "source_repo": "kaionn/pain-collector",
+            "payload": encoded_payload,
+        },
+        token=os.environ.get("PAT_TOKEN"),
+    )
+
+    if not dispatched:
+        gh_client.post_comment(
+            issue_number,
+            "❌ Signal Lab への dispatch に失敗したのだ。Actions ログを確認するのだ。",
+        )
+        return 1
+
+    entry["product_name"] = product_name
+    entry["status"] = "probing"
+    _append_event(entry, "probe", {"product_name": product_name})
+    _save_state(state)
+
+    gh_client.add_labels(issue_number, [LABEL_PROBING])
+    gh_client.post_comment(
+        issue_number,
+        "🧪 Probe 生成を Signal Lab に依頼したのだ。PR ができたら通知が届くのだ。\n\n"
+        f"プロダクト名: `{product_name}`",
+    )
+    _notify_discord(f"🧪 probing: #{issue_number} {product_name}")
     return 0
 
 
@@ -357,6 +509,7 @@ COMMANDS = {
     "pick": cmd_pick,
     "spec": cmd_spec,
     "status": cmd_status,
+    "probe": cmd_probe,
     "reject": cmd_reject,
     "help": cmd_help,
 }

--- a/tests/test_issue_commands.py
+++ b/tests/test_issue_commands.py
@@ -1,0 +1,263 @@
+"""issue_commands.py の /probe ハンドラのユニットテスト.
+
+gh CLI 呼び出し（gh_client 経由）と pipeline_state.json への書き込みはモックし、
+signal-lab へ渡す payload の構築ロジックのみを検証する。
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+
+import pytest
+
+from src import issue_commands
+
+
+ISSUE_BODY = """\
+## ペイン
+
+家計簿を毎日つけるのが面倒くさい。
+
+## 詳細
+
+| 項目 | 値 |
+|---|---|
+| 深刻度 | ★★★☆☆ (3/5) |
+
+## アイデア
+
+レシート撮影だけで自動仕訳する家計簿アプリ。手入力を一切なくす。
+
+## 既存ソリューション
+
+Zaim や MoneyForward はあるが手動修正が多い。
+
+## 市場シグナル
+
+🟡 市場あり・満足度低い（チャンス）
+
+- [Zaim](https://apps.apple.com/jp/app/id123456) ⭐3.8 (1200件) 無料
+- [MoneyForward](https://apps.apple.com/jp/app/id654321) ⭐3.5 (900件) ¥480/月
+
+## ソース
+
+[家計簿アプリの不満まとめ](https://example.com/thread/1)
+
+---
+📅 2026-07-05
+<!-- pain-data:{"pain":"家計簿を毎日つけるのが面倒くさい。","app_idea":"レシート撮影だけで自動仕訳する家計簿アプリ。手入力を一切なくす。","existing_solutions":"Zaim や MoneyForward はあるが手動修正が多い。","severity":3,"willingness_to_pay":"medium","category":"生活"} -->
+"""
+
+
+@pytest.fixture
+def isolated_state(monkeypatch, tmp_path):
+    state_path = tmp_path / "pipeline_state.json"
+    dirty_path = tmp_path / ".state_dirty"
+    monkeypatch.setattr(issue_commands, "PIPELINE_STATE_PATH", str(state_path))
+    monkeypatch.setattr(issue_commands, "STATE_DIRTY_FLAG", str(dirty_path))
+    return tmp_path
+
+
+@pytest.fixture
+def stub_gh(monkeypatch):
+    """gh_client の外部呼び出しを記録するだけのスタブに差し替える."""
+    calls = {"comments": [], "labels": [], "workflow": None}
+
+    monkeypatch.setattr(
+        issue_commands.gh_client,
+        "fetch_issue",
+        lambda issue_number: {
+            "number": issue_number,
+            "title": "[生活] 家計簿を毎日つけるのが面倒くさい",
+            "body": ISSUE_BODY,
+        },
+    )
+    monkeypatch.setattr(
+        issue_commands.gh_client,
+        "post_comment",
+        lambda issue_number, body: calls["comments"].append((issue_number, body)) or True,
+    )
+    monkeypatch.setattr(
+        issue_commands.gh_client,
+        "add_labels",
+        lambda issue_number, labels: calls["labels"].append((issue_number, labels)) or True,
+    )
+
+    def _fake_trigger_workflow(repo, workflow, inputs, *, token=None):
+        calls["workflow"] = {
+            "repo": repo,
+            "workflow": workflow,
+            "inputs": inputs,
+            "token": token,
+        }
+        return True
+
+    monkeypatch.setattr(issue_commands.gh_client, "trigger_workflow", _fake_trigger_workflow)
+    monkeypatch.setattr(
+        issue_commands, "generate_product_name",
+        type("_M", (), {"generate": staticmethod(lambda title, issue_number: "kakeibo-auto")}),
+    )
+    monkeypatch.setattr(issue_commands, "_notify_discord", lambda message: None)
+    return calls
+
+
+class TestBuildProbePayload:
+    def test_includes_all_receiver_contract_fields(self):
+        payload = issue_commands._build_probe_payload(
+            42, "[生活] 家計簿を毎日つけるのが面倒くさい", ISSUE_BODY, "kakeibo-auto",
+        )
+
+        expected_keys = {
+            "slug", "title", "tagline", "pain", "idea",
+            "source_url", "source_title", "market_apps",
+            "severity", "monetization",
+        }
+        assert expected_keys.issubset(payload.keys())
+
+    def test_slug_is_kebab_case_ascii(self):
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", ISSUE_BODY, "kakeibo-auto",
+        )
+        assert re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", payload["slug"])
+
+    def test_extracts_source_url_and_title(self):
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", ISSUE_BODY, "kakeibo-auto",
+        )
+        assert payload["source_url"] == "https://example.com/thread/1"
+        assert payload["source_title"] == "家計簿アプリの不満まとめ"
+
+    def test_source_url_is_null_when_no_source_section(self):
+        body_without_source = ISSUE_BODY.split("## ソース")[0]
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", body_without_source, "kakeibo-auto",
+        )
+        assert payload["source_url"] is None
+        assert payload["source_title"] is None
+
+    def test_extracts_market_apps(self):
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", ISSUE_BODY, "kakeibo-auto",
+        )
+        assert payload["market_apps"] == [
+            {
+                "name": "Zaim",
+                "url": "https://apps.apple.com/jp/app/id123456",
+                "rating": "3.8",
+                "reviews": 1200,
+                "price": "無料",
+            },
+            {
+                "name": "MoneyForward",
+                "url": "https://apps.apple.com/jp/app/id654321",
+                "rating": "3.5",
+                "reviews": 900,
+                "price": "¥480/月",
+            },
+        ]
+
+    def test_market_apps_empty_when_no_section(self):
+        body_without_market = (
+            "## ペイン\n\n家計簿が面倒\n\n"
+            "## ソース\n\n[出典](https://example.com/thread/2)\n"
+        )
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", body_without_market, "kakeibo-auto",
+        )
+        assert payload["market_apps"] == []
+
+    def test_severity_and_monetization_from_pain_data(self):
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", ISSUE_BODY, "kakeibo-auto",
+        )
+        assert payload["severity"] == 3
+        assert payload["monetization"] == "medium"
+
+    def test_falls_back_when_pain_data_missing(self):
+        """pain-data メタデータが無い古い Issue でも例外にならずフォールバックする."""
+        legacy_body = "## ペイン\n\n古いペイン\n"
+        payload = issue_commands._build_probe_payload(
+            1, "古いタイトル", legacy_body, "legacy-app",
+        )
+        assert payload["pain"] == "古いタイトル"
+        assert payload["severity"] == 3
+        assert payload["monetization"] == "medium"
+        assert payload["source_url"] is None
+        assert payload["market_apps"] == []
+
+
+class TestPayloadBase64Roundtrip:
+    def test_decoded_payload_matches_original_json(self):
+        payload = issue_commands._build_probe_payload(
+            42, "タイトル", ISSUE_BODY, "kakeibo-auto",
+        )
+        encoded = base64.b64encode(
+            json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        ).decode("ascii")
+
+        decoded = json.loads(base64.b64decode(encoded).decode("utf-8"))
+        assert decoded == payload
+
+
+class TestCmdProbe:
+    def test_dispatches_to_signal_lab_with_expected_inputs(self, isolated_state, stub_gh):
+        rc = issue_commands.cmd_probe(42)
+
+        assert rc == 0
+        workflow_call = stub_gh["workflow"]
+        assert workflow_call["repo"] == "kaionn/signal-lab"
+        assert workflow_call["workflow"] == "probe-request.yml"
+        assert workflow_call["inputs"]["issue_number"] == "42"
+        assert workflow_call["inputs"]["source_repo"] == "kaionn/pain-collector"
+
+        decoded = json.loads(base64.b64decode(workflow_call["inputs"]["payload"]).decode("utf-8"))
+        assert decoded["slug"] == "kakeibo-auto"
+
+    def test_auto_picks_when_not_picked(self, isolated_state, stub_gh):
+        issue_commands.cmd_probe(42)
+
+        state = issue_commands._load_state()
+        entry = issue_commands._find_entry(state, 42)
+        assert entry is not None
+        assert entry["status"] == "probing"
+        assert entry["product_name"] == "kakeibo-auto"
+
+    def test_reuses_existing_product_name(self, isolated_state, stub_gh):
+        issue_commands._save_state({
+            "picked": [{
+                "issue_number": 42,
+                "product_name": "already-named",
+                "status": "spec-ready",
+                "events": [],
+            }],
+        })
+
+        issue_commands.cmd_probe(42)
+
+        workflow_call = stub_gh["workflow"]
+        decoded = json.loads(base64.b64decode(workflow_call["inputs"]["payload"]).decode("utf-8"))
+        assert decoded["slug"] == "already-named"
+
+    def test_uses_pat_token_for_dispatch(self, isolated_state, stub_gh, monkeypatch):
+        monkeypatch.setenv("PAT_TOKEN", "fake-pat-token")
+
+        issue_commands.cmd_probe(42)
+
+        assert stub_gh["workflow"]["token"] == "fake-pat-token"
+
+    def test_posts_failure_comment_when_dispatch_fails(self, isolated_state, monkeypatch, stub_gh):
+        monkeypatch.setattr(
+            issue_commands.gh_client, "trigger_workflow",
+            lambda *args, **kwargs: False,
+        )
+
+        rc = issue_commands.cmd_probe(42)
+
+        assert rc == 1
+        assert any("失敗" in body for _, body in stub_gh["comments"])
+        state = issue_commands._load_state()
+        assert issue_commands._find_entry(state, 42) is None or \
+            issue_commands._find_entry(state, 42).get("status") != "probing"


### PR DESCRIPTION
## 関連URL

- Signal Lab（受信側）: https://github.com/kaionn/signal-lab
- 受信ワークフロー: https://github.com/kaionn/signal-lab/blob/main/.github/workflows/probe-request.yml
- Plan: ~/.claude/plans/signal-lab/signal-lab-bootstrap.md（ローカル）

## 説明

旧機構（/approve → mvp-factory で MVP 自動生成）は、需要不明のまま実装コストを先払いする構造だった（84 案 Selected 0・生成 MVP 未公開の実績）。新機構では /probe が Signal Lab に検証 LP の生成を依頼し、待機リスト登録などの実シグナルを見てから本実装する。

## Before / After（コマンド挙動）

- Before: `/approve` → mvp-factory の build.yml を dispatch（spec 必須、MVP リポジトリ自動生成）
- After: `/approve` → 廃止案内コメントのみ（dispatch なし）/ **`/probe`（新設）** → picked 自動昇格 → ペイン・出典・競合を payload 化して signal-lab の probe-request.yml を dispatch → state を `probing` に更新
- 収集・digest 系の出力に変化なし

## 設計判断の要点

- payload の構造化データは notify.py の既存埋め込みメタデータを再利用し、Issue 本文パースの新設を最小化
- gh_client.trigger_workflow は token 明示指定時のみ GH_TOKEN を上書き（他コマンドの権限を広げない）

## CI 検証

- uv run pytest 全 418 件 green（新規 14 件含む）
- 実 dispatch の E2E は signal-lab 側 Secrets（CLAUDE_CODE_OAUTH_TOKEN）と PAT の対象 repo 追加後にテスト Issue で実施予定